### PR TITLE
Fix crashes for packages without license URL or a "NOASSERTION" 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -132,6 +132,9 @@ resharper_blank_lines_after_multiline_statements = 1
 # Purpose: Don't put elements of an array on new lines, unless the length exceeds the maximum line length.
 resharper_wrap_array_initializer_style = chop_always
 
+# Start each element in a object or collection initializer on a new line
+resharper_wrap_object_and_collection_initializer_style = chop_always
+
 # Purpose: An item within a C# enumeration is missing an Xml documentation header
 # Reason: Some enums are self-explanatory
 dotnet_diagnostic.ca1062.severity = suggestion

--- a/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -10,9 +10,14 @@ namespace PackageGuard.Core
     {
         public DenyList() { }
     }
+    public sealed class LicenseFetcher
+    {
+        public LicenseFetcher(Microsoft.Extensions.Logging.ILogger logger) { }
+        public System.Threading.Tasks.Task AmendWithMissingLicenseInformation(PackageGuard.Core.PackageInfo package) { }
+    }
     public class NuGetPackageAnalyzer
     {
-        public NuGetPackageAnalyzer(Microsoft.Extensions.Logging.ILogger logger) { }
+        public NuGetPackageAnalyzer(Microsoft.Extensions.Logging.ILogger logger, PackageGuard.Core.LicenseFetcher licenseFetcher) { }
         public System.Threading.Tasks.Task CollectPackageMetadata(string projectPath, string packageName, NuGet.Versioning.NuGetVersion packageVersion, PackageGuard.Core.PackageInfoCollection packages) { }
     }
     public class NuGetProjectAnalyzer
@@ -34,9 +39,9 @@ namespace PackageGuard.Core
         public string? RepositoryUrl { get; set; }
         public string? Source { get; set; }
         public string Version { get; set; }
-        public void Add(string projectPath) { }
         public bool SatisfiesRange(string name, string? versionRange = null) { }
         public override string ToString() { }
+        public void TrackAsUsedInProject(string projectPath) { }
     }
     public class PackageInfoCollection : System.Collections.Generic.IEnumerable<PackageGuard.Core.PackageInfo>, System.Collections.IEnumerable
     {

--- a/Src/PackageGuard.ApiVerificationTests/PackageGuard.ApiVerificationTests.csproj
+++ b/Src/PackageGuard.ApiVerificationTests/PackageGuard.ApiVerificationTests.csproj
@@ -7,13 +7,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PublicApiGenerator" Version="11.4.5" />
+    <PackageReference Include="PublicApiGenerator" Version="11.4.6" />
     <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageReference Include="Verify.Xunit" Version="29.1.0" />
+    <PackageReference Include="Verify.Xunit" Version="30.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Src/PackageGuard.Core/LicenseFetcher.cs
+++ b/Src/PackageGuard.Core/LicenseFetcher.cs
@@ -1,0 +1,115 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+namespace PackageGuard.Core;
+
+public sealed class LicenseFetcher(ILogger logger)
+{
+    private static readonly HttpClient HttpClient = new();
+
+    static LicenseFetcher()
+    {
+        HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PackageGuard", "v1"));
+    }
+
+    public async Task AmendWithMissingLicenseInformation(PackageInfo package)
+    {
+        if (package.License is null)
+        {
+            logger.LogInformation("Package {Name} {Version} does not have a license. Fetching it separately",
+                package.Id, package.Version);
+
+            await TryFetchLicenseFromGitHubMetaData(package);
+        }
+
+        if (package.License is null)
+        {
+            await TryFetchLicenseFromDownloadUrl(package);
+        }
+
+        logger.LogInformation("Determined the license to be {License}", package.License);
+    }
+
+    private async Task TryFetchLicenseFromGitHubMetaData(PackageInfo package)
+    {
+        if (package.RepositoryUrl is not null)
+        {
+            string? url = GetGitHubLicenseUrl(package.RepositoryUrl);
+
+            if (url is not null)
+            {
+                string licenseJson = await HttpClient.GetStringAsync(url);
+
+                using JsonDocument doc = JsonDocument.Parse(licenseJson);
+                package.License = doc.RootElement.GetProperty("license").GetProperty("spdx_id").GetString();
+
+                if (package.License?.Equals("noassertion", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    package.License = null;
+                }
+            }
+        }
+    }
+
+    private string? GetGitHubLicenseUrl(string repositoryUrl)
+    {
+        string? url = null;
+
+        const string validCharacters = "[a-zA-Z0-9._-]";
+
+        var match = Regex.Match(repositoryUrl,
+            $@"raw.githubusercontent.com\/(?<owner>{validCharacters}+?)\/(?<repo>{validCharacters}+)");
+
+        if (match.Length == 0)
+        {
+            match = Regex.Match(repositoryUrl,
+                $@"github.com\/(?<owner>{validCharacters}+?)\/(?<repo>{validCharacters}+)");
+        }
+
+        if (match.Length > 0)
+        {
+            string owner = match.Groups["owner"].Value;
+            string repo = match.Groups["repo"].Value;
+
+            url = $"https://api.github.com/repos/{owner}/{repo}/license";
+        }
+
+        return url;
+    }
+
+    private async Task TryFetchLicenseFromDownloadUrl(PackageInfo package)
+    {
+        package.License = "Unknown";
+
+        if (package.LicenseUrl is { Length: > 0 })
+        {
+            try
+            {
+                string licenseText = await HttpClient.GetStringAsync(package.LicenseUrl);
+
+                if (licenseText.Contains("MIT license", StringComparison.OrdinalIgnoreCase))
+                {
+                    package.License = "MIT";
+                }
+                else if (licenseText.Contains("Apache License", StringComparison.OrdinalIgnoreCase))
+                {
+                    package.License = "Apache-2.0";
+                }
+                else if (licenseText.Contains("GNU General Public License", StringComparison.OrdinalIgnoreCase))
+                {
+                    package.License = "GPL-3.0";
+                }
+                else
+                {
+                    logger.LogWarning("Did not detect any well-known licenses in {URL}", package.LicenseUrl);
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogWarning("Failed to extract the license from URL {URL}: {ErrorCode}", package.LicenseUrl, ex.Message);
+            }
+        }
+    }
+}

--- a/Src/PackageGuard.Core/PackageGuard.Core.csproj
+++ b/Src/PackageGuard.Core/PackageGuard.Core.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.8.2" />
     <PackageReference Include="Microsoft.Build" Version="17.11.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.13.2" />
     <PackageReference Include="NuGet.Versioning" Version="6.13.2" />
   </ItemGroup>

--- a/Src/PackageGuard.Core/PackageInfo.cs
+++ b/Src/PackageGuard.Core/PackageInfo.cs
@@ -34,7 +34,7 @@ public class PackageInfo
         return range.Satisfies(NuGetVersion.Parse(Version));
     }
 
-    public void Add(string projectPath)
+    public void TrackAsUsedInProject(string projectPath)
     {
         Projects.Add(projectPath);
     }

--- a/Src/PackageGuard.Specs/LicenseFetcherSpecs.cs
+++ b/Src/PackageGuard.Specs/LicenseFetcherSpecs.cs
@@ -1,0 +1,69 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PackageGuard.Core;
+
+namespace PackageGuard.Specs;
+
+[TestClass]
+public class LicenseFetcherSpecs
+{
+    [TestMethod]
+    public async Task Nothing_needs_to_be_done_for_a_package_that_already_has_a_license()
+    {
+        // Arrange
+        var fetcher = new LicenseFetcher(NullLogger.Instance);
+
+        var package = new PackageInfo
+        {
+            Id = "Bogus",
+            Version = "1.0.0",
+            License = "MIT"
+        };
+
+        // Act / Assert
+        await fetcher.AmendWithMissingLicenseInformation(package);
+    }
+
+    [TestMethod]
+    public async Task A_package_without_license_or_license_url_is_properly_handled()
+    {
+        // Arrange
+        var fetcher = new LicenseFetcher(NullLogger.Instance);
+
+        var package = new PackageInfo
+        {
+            Id = "Bogus",
+            Version = "1.0.0",
+            License = null,
+            LicenseUrl = null
+        };
+
+        // Act
+        await fetcher.AmendWithMissingLicenseInformation(package);
+
+        // Assert
+        package.License.Should().Be("Unknown");
+    }
+
+    [TestMethod]
+    public async Task A_no_assertion_license_is_treated_as_unknown()
+    {
+        // Arrange
+        var fetcher = new LicenseFetcher(NullLogger.Instance);
+
+        var package = new PackageInfo
+        {
+            Id = "xunit.abstractions",
+            Version = "2.0.3",
+            RepositoryUrl = "https://github.com/xunit/xunit"
+        };
+
+        // Act
+        await fetcher.AmendWithMissingLicenseInformation(package);
+
+        // Assert
+        package.License.Should().Be("Unknown");
+    }
+}

--- a/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
+++ b/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
@@ -16,6 +16,7 @@
       </PackageReference>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
       <PackageReference Include="MSTest" Version="3.8.3" />
+      <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
       </ItemGroup>
 
     <ItemGroup>

--- a/Src/PackageGuard/AnalyzeCommand.cs
+++ b/Src/PackageGuard/AnalyzeCommand.cs
@@ -31,7 +31,7 @@ internal sealed class AnalyzeCommand(ILogger logger) : AsyncCommand<AnalyzeComma
             }
         };
 
-        var analyzer = new NuGetProjectAnalyzer(projectScanner, new NuGetPackageAnalyzer(logger))
+        var analyzer = new NuGetProjectAnalyzer(projectScanner, new NuGetPackageAnalyzer(logger, new LicenseFetcher(logger)))
         {
             ProjectPath = settings.ProjectPath, Logger = logger,
         };

--- a/Src/PackageGuard/PackageGuard.csproj
+++ b/Src/PackageGuard/PackageGuard.csproj
@@ -26,17 +26,17 @@
       <PackageReference Include="CliWrap" Version="3.8.2" />
       <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
       <PackageReference Include="Microsoft.Build" Version="17.11.4" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.4" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
       <PackageReference Include="Serilog" Version="4.2.0" />
       <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-      <PackageReference Include="Spectre.Console" Version="0.49.2-preview.0.77" />
-      <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
+      <PackageReference Include="Spectre.Console" Version="0.50.0" />
+      <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
       <PackageReference Include="NuGet.ProjectModel" Version="6.13.2" />
-      <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.6.0" />
+      <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.7.0" />
       <PackageReference Include="vertical-spectreconsolelogger" Version="0.10.1-dev.20241201.35" />
     </ItemGroup>
 


### PR DESCRIPTION
Fix crashes for packages without license URL or a "NOASSERTION" 

This pull request introduces a significant refactoring and enhancement of the license-fetching logic in the `PackageGuard` project, along with updates to dependencies and improvements to test coverage. The main changes include the extraction of license-fetching functionality into a new `LicenseFetcher` class, updates to dependency versions, and the addition of new unit tests for the refactored functionality.

#19