### PR TITLE
Specifying a specific .csproj file requires it to exist

### DIFF
--- a/Src/PackageGuard.Core/CSharpProjectScanner.cs
+++ b/Src/PackageGuard.Core/CSharpProjectScanner.cs
@@ -29,8 +29,7 @@ public class CSharpProjectScanner(ILogger logger)
             }
             else
             {
-                logger.LogWarning("Project {Path} does not exist", path);
-                return new List<string>();
+                throw new FileNotFoundException($"The project file \"{pathy}\" does not exist");
             }
         }
 

--- a/Src/PackageGuard.Specs/CSharpProjectAnalyzerSpecs.cs
+++ b/Src/PackageGuard.Specs/CSharpProjectAnalyzerSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -254,7 +255,7 @@ public class CSharpProjectAnalyzerSpecs
                 ProjectPath = ProjectPath,
                 AllowList = new AllowList
                 {
-                     Packages =
+                    Packages =
                     [
                         new PackageSelector("FluentAssertions", "[7.0.0,8.0.0)"),
                     ]
@@ -317,5 +318,27 @@ public class CSharpProjectAnalyzerSpecs
 
         // Assert
         violations.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Specifying_a_specific_project_file_requires_it_to_exist()
+    {
+        // Arrange
+        var analyzer =
+            new CSharpProjectAnalyzer(cSharpProjectScanner, nuGetPackageAnalyzer)
+            {
+                ProjectPath = ChainablePath.Current / "NonExistingFolder" / "NonExisting.csproj",
+                AllowList = new AllowList
+                {
+                    Licenses = ["mit"]
+                }
+            };
+
+        // Act
+        var act = () => analyzer.ExecuteAnalysis();
+
+        // Assert
+        await act.Should().ThrowAsync<FileNotFoundException>()
+            .WithMessage("*file*NonExisting.csproj*does not exist*");
     }
 }


### PR DESCRIPTION
Before this fix, specifying a specific `.csproj` that did not actually exist, only resulted in a warning. Now, it will fail the analysis.