### PR TITLE
Allow packages from a specific feed regardless of their license or version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ The tool is available as [a NuGet Tool package](https://www.nuget.org/packages/p
 
   `dotnet tool install PackageGuard --global`
 
-Then use `packageguard -h` to see a list of options.
+Then use `packageguard --help` to see a list of options.
 
-## How do I use it?
+## How do I configure it?
 
-First, you need to create a JSON configuration file listing the packages and/or licenses you want to allow/deny list. By default, this file is called `config.json` and loaded from the working directory, but you can override that using the `--configPath` CLI parameter. The config file needs to have the following format:
+First, you need to create a JSON configuration file listing the packages and/or licenses you want to allow/deny list. By default, this file is called `config.json` and loaded from the working directory, but you can override that using the `--configpath` CLI parameter. The config file needs to have the following format:
 
 ```json
 {
@@ -67,24 +67,55 @@ First, you need to create a JSON configuration file listing the packages and/or 
               "MIT",
           ],
           "packages": [
-              "FluentAssertions/[7.0.0,8.0.0)"
+              "MyPackage/[7.0.0,8.0.0)"
           ]            
         },
         "deny": {
           "licenses": [],
           "packages": [
-            "moq"
+            "ProhibitedPackage"
           ]
         }
     }
 }
 ```
 
-In this example, only NuGet packages with the MIT or Apache 2.0 licenses are allowed, the use of `moq` is prohibited, and `FluentAssertions` should stick to version 7 only. Both the `allow` and `deny` sections support both the `licenses` and `packages` properties. License names are case-insensitive and follow the [SPDX identifier](https://spdx.org/licenses/) naming conventions.Package names can include just the NuGet ID but may also include a [NuGet-compatible version (range)](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort) separated by `/`.
+In this example, only NuGet packages with the MIT or Apache 2.0 licenses are allowed, the use of the package `ProhibitedPackage` is prohibited, and `MyPackage` should stick to version 7 only. Both the `allow` and `deny` sections support both the `licenses` and `packages` properties. 
+
+License names are case-insensitive and follow the [SPDX identifier](https://spdx.org/licenses/) naming conventions. Package names can include just the NuGet ID but may also include a [NuGet-compatible version (range)](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort) separated by `/`. Here's a summary of the possible notations:
+
+
+| Notation        | Valid versions     |
+|-----------------|--------------------|
+| "Package/1.0"   | 1.0            |
+| "Package/[1.0,)"| v ≥ 1.0            |
+| "Package/(1.0,)"          | v > 1.0            |
+| "Package/[1.0]"           | v == 1.0           |
+| "Package/(,1.0]"          | v ≤ 1.0            |
+| "Package/(,1.0)"          | v < 1.0            |
+| "Package/[1.0,2.0]"       | 1.0 ≤ v ≤ 2.0      |
+| "Package/(1.0,2.0)"       | 1.0 < v < 2.0      |
+| "Package/[1.0,2.0)"       | 1.0 ≤ v < 2.0      |
+
+You can also tell PackageGuard to allow all packages from a particular feed, even if a package on that feed doesn't meet the licenses or packages listed under `allow`. Just add the element `feeds` under the `allow` element and specify a wildcard pattern that matches the name or URL of the feed.
+
+```json
+{
+    "settings": {
+        "allow": {
+            "feeds": ["*dev.azure.com*"]
+        }
+    }
+}
+```
+
+TODO
+
+## How do I use it?
 
 With this configuration in place, simply invoke PackageGuard like this
 
-`packageguard --configPath <path-to-config-file> <path-to-solution-file-or-project>`
+`packageguard --configpath <path-to-config-file> <path-to-solution-file-or-project>`
 
 If you pass a directory, PackageGuard will try to find the `.sln` files there. But you can also specify a specific `.csproj` to scan. 
 
@@ -100,8 +131,6 @@ This is a rough list of items from my personal backlog that I'll be working on t
 
 **Complete the MVP**
 - Allow specifying the location of `dotnet.exe`
-- Allow forcing the restore
-- Allow preventing restore
 - Allow ignoring certain .csproj files or folders using Globs or wildcards (e.g. build.csproj)
 - Allow marking all violations as a warning
 - Allow marking individual violations as a warning
@@ -111,7 +140,7 @@ This is a rough list of items from my personal backlog that I'll be working on t
 - Expose the internal engine through the `PackageGuard.Core` NuGet package
 - Add support for [Nuke](https://nuke.build/)
 - Allow loading settings from the directory of the scanned project and move up if not found
-Display the reason why a package was marked as a violation
+- Display the reason why a package was marked as a violation
 
 **Major features**
 - Add support for the new .slnx file

--- a/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -4,6 +4,7 @@ namespace PackageGuard.Core
     public class AllowList : PackageGuard.Core.PackagePolicy
     {
         public AllowList() { }
+        public System.Collections.Generic.List<string> Feeds { get; set; }
     }
     public class CSharpProjectAnalyzer
     {
@@ -52,8 +53,10 @@ namespace PackageGuard.Core
         public string? LicenseUrl { get; set; }
         public System.Collections.Generic.List<string> Projects { get; set; }
         public string? RepositoryUrl { get; set; }
-        public string? Source { get; set; }
+        public string Source { get; set; }
+        public string SourceUrl { get; set; }
         public string Version { get; set; }
+        public bool MatchesFeed(string feedWildcard) { }
         public bool SatisfiesRange(string name, string? versionRange = null) { }
         public override string ToString() { }
         public void TrackAsUsedInProject(string projectPath) { }
@@ -80,7 +83,9 @@ namespace PackageGuard.Core
     }
     public class PolicyViolation : System.IEquatable<PackageGuard.Core.PolicyViolation>
     {
-        public PolicyViolation(string PackageId, string Version, string License, string[] Projects) { }
+        public PolicyViolation(string PackageId, string Version, string License, string[] Projects, string FeedName, string FeedUrl) { }
+        public string FeedName { get; init; }
+        public string FeedUrl { get; init; }
         public string License { get; init; }
         public string PackageId { get; init; }
         public string[] Projects { get; init; }

--- a/Src/PackageGuard.Core/AllowList.cs
+++ b/Src/PackageGuard.Core/AllowList.cs
@@ -2,8 +2,24 @@
 
 public class AllowList : PackagePolicy
 {
-    internal override bool Complies(PackageInfo package)
+    /// <summary>
+    /// One or more NuGet feeds which packages are allowed regardless of version of license.
+    /// </summary>
+    /// <value>
+    /// Each feed is wildcard string that can match the NuGet feed name or URL.
+    /// </value>
+    public List<string> Feeds { get; set; } = [];
+
+    /// <summary>
+    /// Verifies if the given package complies given the feeds, packages and licenses defined in this allow list.
+    /// </summary>
+    internal bool Allows(PackageInfo package)
     {
+        if (PackageIsExplicitlyAllowedByFeed(package))
+        {
+            return true;
+        }
+
         bool licenseComplies = !(Licenses.Any() && !Licenses.Contains(package.License!, StringComparer.OrdinalIgnoreCase));
 
         bool packageComplies = true;
@@ -19,13 +35,16 @@ public class AllowList : PackagePolicy
                 }
                 else
                 {
-                    // If the package (and version) is allowlisted, we don't care about the license violation
+                    // If the package (and version) is allowed, we don't care about the license violation
                     licenseComplies = true;
                 }
+
                 break;
             }
         }
 
         return licenseComplies && packageComplies;
     }
+
+    private bool PackageIsExplicitlyAllowedByFeed(PackageInfo package) => Feeds.Any(package.MatchesFeed);
 }

--- a/Src/PackageGuard.Core/CSharpProjectAnalyzer.cs
+++ b/Src/PackageGuard.Core/CSharpProjectAnalyzer.cs
@@ -83,9 +83,9 @@ public class CSharpProjectAnalyzer(CSharpProjectScanner scanner, NuGetPackageAna
 
         foreach (PackageInfo package in packages)
         {
-            if (!AllowList.Complies(package) || !DenyList.Complies(package))
+            if (!AllowList.Allows(package) || DenyList.Denies(package))
             {
-                violations.Add(new PolicyViolation(package.Id, package.Version, package.License!, package.Projects.ToArray()));
+                violations.Add(new PolicyViolation(package.Id, package.Version, package.License!, package.Projects.ToArray(), package.Source, package.SourceUrl));
             }
         }
 

--- a/Src/PackageGuard.Core/DenyList.cs
+++ b/Src/PackageGuard.Core/DenyList.cs
@@ -2,11 +2,14 @@
 
 public class DenyList : PackagePolicy
 {
-    internal override bool Complies(PackageInfo package)
+    /// <summary>
+    /// Determines if the given package is denied by the licenses or packages defined in this deny list.
+    /// </summary>
+    internal bool Denies(PackageInfo package)
     {
         if (Licenses.Any() && Licenses.Contains(package.License!, StringComparer.OrdinalIgnoreCase))
         {
-            return false;
+            return true;
         }
 
         foreach (PackageSelector selector in Packages)
@@ -14,10 +17,10 @@ public class DenyList : PackagePolicy
             if (package.Id == selector.Id &&
                 (selector.VersionRange is null || package.SatisfiesRange(selector.Id, selector.VersionRange)))
             {
-                return false;
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 }

--- a/Src/PackageGuard.Core/NuGetPackageAnalyzer.cs
+++ b/Src/PackageGuard.Core/NuGetPackageAnalyzer.cs
@@ -99,7 +99,8 @@ public class NuGetPackageAnalyzer(ILogger logger, LicenseFetcher licenseFetcher)
                     RepositoryUrl = packageInfo.ProjectUrl?.ToString(),
                     License = packageInfo.LicenseMetadata?.License,
                     LicenseUrl = packageInfo.LicenseUrl?.ToString(),
-                    Source = repository.PackageSource.Source
+                    Source = repository.PackageSource.Name,
+                    SourceUrl = repository.PackageSource.Source
                 };
             }
         }

--- a/Src/PackageGuard.Core/PackageInfo.cs
+++ b/Src/PackageGuard.Core/PackageInfo.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using NuGet.Versioning;
 
 namespace PackageGuard.Core;
@@ -12,9 +13,14 @@ public class PackageInfo
     public List<string> Projects { get; set; } = new();
 
     /// <summary>
-    /// Gets or sets the source URL of the NuGet source that was used to fetch the metadata.
+    /// Gets or sets the name of the NuGet source that was used to fetch the metadata.
     /// </summary>
-    public string? Source { get; set; }
+    public string Source { get; set; } = "";
+
+    /// <summary>
+    /// Gets or sets the Url of the NuGet source that was used to fetch the metadata.
+    /// </summary>
+    public string SourceUrl { get; set; } = "";
 
     public string? RepositoryUrl { get; set; }
 
@@ -40,4 +46,18 @@ public class PackageInfo
     }
 
     public override string ToString() => $"{Id}/{Version} ({License})";
+
+    /// <summary>
+    /// Returns <c>true</c> if the name or URL of the feed where this package was found matches the given wildcard.
+    /// </summary>
+    public bool MatchesFeed(string feedWildcard)
+    {
+        return IsWildcardMatch(Source, feedWildcard) || IsWildcardMatch(SourceUrl, feedWildcard);
+    }
+
+    private static bool IsWildcardMatch(string text, string pattern)
+    {
+        var escapedPattern = Regex.Escape(pattern).Replace("\\*", ".*");
+        return Regex.IsMatch(text, $"^{escapedPattern}$", RegexOptions.IgnoreCase);
+    }
 }

--- a/Src/PackageGuard.Core/PackagePolicy.cs
+++ b/Src/PackageGuard.Core/PackagePolicy.cs
@@ -13,6 +13,4 @@ public abstract class PackagePolicy
     /// Checks if there are any policies defined either in Packages or Licenses.
     /// </summary>
     internal bool HasPolicies => Packages.Any() || Licenses.Any();
-
-    internal abstract bool Complies(PackageInfo package);
 }

--- a/Src/PackageGuard.Core/PolicyViolation.cs
+++ b/Src/PackageGuard.Core/PolicyViolation.cs
@@ -1,3 +1,3 @@
 ﻿namespace PackageGuard.Core;
 
-public record PolicyViolation(string PackageId, string Version, string License, string[] Projects);
+public record PolicyViolation(string PackageId, string Version, string License, string[] Projects, string FeedName, string FeedUrl);

--- a/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
+++ b/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
@@ -39,6 +39,9 @@
       <None Include="TestCases\SimpleApp\UnitTest1.cs">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="TestCases\UnknownLicense\NuGet.config">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>
@@ -48,6 +51,13 @@
       <Content Include="TestCases\SimpleApp\SimpleApp.sln">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
+      <None Include="TestCases\UnknownLicense\ConsoleApp.csproj">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Include="TestCases\UnknownLicense\ConsoleApp.sln">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="TestCases\UnknownLicense\Program.cs" />
     </ItemGroup>
 
 </Project>

--- a/Src/PackageGuard.Specs/TestCases/UnknownLicense/ConsoleApp.csproj
+++ b/Src/PackageGuard.Specs/TestCases/UnknownLicense/ConsoleApp.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/Src/PackageGuard.Specs/TestCases/UnknownLicense/ConsoleApp.sln
+++ b/Src/PackageGuard.Specs/TestCases/UnknownLicense/ConsoleApp.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "ConsoleApp1.csproj", "{44E5B80A-6A1F-464D-9EBD-7524110DB91E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{44E5B80A-6A1F-464D-9EBD-7524110DB91E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44E5B80A-6A1F-464D-9EBD-7524110DB91E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44E5B80A-6A1F-464D-9EBD-7524110DB91E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44E5B80A-6A1F-464D-9EBD-7524110DB91E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Src/PackageGuard.Specs/TestCases/UnknownLicense/NuGet.config
+++ b/Src/PackageGuard.Specs/TestCases/UnknownLicense/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/Src/PackageGuard.Specs/TestCases/UnknownLicense/Program.cs
+++ b/Src/PackageGuard.Specs/TestCases/UnknownLicense/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/Src/PackageGuard/AnalyzeCommand.cs
+++ b/Src/PackageGuard/AnalyzeCommand.cs
@@ -54,6 +54,7 @@ internal sealed class AnalyzeCommand(ILogger logger) : AsyncCommand<AnalyzeComma
             {
                 logger.LogInformation("{Id} {Version}", violation.PackageId, violation.Version);
                 logger.LogInformation("- License: {License}", violation.License);
+                logger.LogInformation("- Feed: {Source} ({Url})", violation.FeedName, violation.FeedUrl);
 
                 if (violation.Projects.Any())
                 {
@@ -86,6 +87,7 @@ internal sealed class AnalyzeCommand(ILogger logger) : AsyncCommand<AnalyzeComma
         }
 
         analyzer.AllowList.Licenses.AddRange(globalSettings.Allow.Licenses);
+        analyzer.AllowList.Feeds.AddRange(globalSettings.Allow.Feeds);
 
         foreach (string package in globalSettings.Deny.Packages)
         {

--- a/Src/PackageGuard/GlobalSettings.cs
+++ b/Src/PackageGuard/GlobalSettings.cs
@@ -5,7 +5,7 @@ namespace PackageGuard;
 public class GlobalSettings
 {
     [UsedImplicitly]
-    public PolicyItem Allow { get; set; } = new();
+    public AllowPolicyItem Allow { get; set; } = new();
 
     [UsedImplicitly]
     public PolicyItem Deny { get; set; } = new();
@@ -17,5 +17,11 @@ public class GlobalSettings
 
         [UsedImplicitly]
         public string[] Licenses { get; set; } = [];
+    }
+
+    public class AllowPolicyItem : PolicyItem
+    {
+        [UsedImplicitly]
+        public string[] Feeds { get; set; } = [];
     }
 }


### PR DESCRIPTION
You can now tell PackageGuard to allow all packages from a particular feed, even if a package on that feed doesn't meet the licenses or packages listed under `allow`. Just add the element `feeds` under the `allow` element and specify a wildcard pattern that matches the name or URL of the feed.

```json
{
    "settings": {
        "allow": {
            "feeds": ["*dev.azure.com*"]
        }
    }
}
```

#19 