### PR TITLE
Properly detect the license of certain Microsoft packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ First, you need to create a JSON configuration file listing the packages and/or 
 
 In this example, only NuGet packages with the MIT or Apache 2.0 licenses are allowed, the use of the package `ProhibitedPackage` is prohibited, and `MyPackage` should stick to version 7 only. Both the `allow` and `deny` sections support the `licenses` and `packages` properties. But licenses and packages listed under `allow` have precedence over those under the `deny` section.
 
-License names are case-insensitive and follow the [SPDX identifier](https://spdx.org/licenses/) naming conventions. Package names can include just the NuGet ID but may also include a [NuGet-compatible version (range)](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort) separated by `/`. Here's a summary of the possible notations:
+License names are case-insensitive and follow the [SPDX identifier](https://spdx.org/licenses/) naming conventions, but we have special support for certain proprietary Microsoft licenses such as used by the `Microsoft.AspNet.WebApi*` packages. For those, we support using the license name `Microsoft .NET Library License`.
+
+Package names can include just the NuGet ID but may also include a [NuGet-compatible version (range)](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort) separated by `/`. Here's a summary of the possible notations:
 
 
 | Notation        | Valid versions     |

--- a/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -38,6 +38,10 @@ namespace PackageGuard.Core
         public bool SkipRestore { get; set; }
         public NuGet.ProjectModel.LockFile? GetPackageLockFile(string path) { }
     }
+    public interface IFetchLicense
+    {
+        System.Threading.Tasks.Task FetchLicenseAsync(PackageGuard.Core.PackageInfo package);
+    }
     public sealed class LicenseFetcher
     {
         public LicenseFetcher(Microsoft.Extensions.Logging.ILogger logger) { }
@@ -94,5 +98,18 @@ namespace PackageGuard.Core
         public string PackageId { get; init; }
         public string[] Projects { get; init; }
         public string Version { get; init; }
+    }
+}
+namespace PackageGuard.Core.FetchingStrategies
+{
+    public class GitHubLicenseFetcher : PackageGuard.Core.IFetchLicense
+    {
+        public GitHubLicenseFetcher() { }
+        public System.Threading.Tasks.Task FetchLicenseAsync(PackageGuard.Core.PackageInfo package) { }
+    }
+    public class UrlLicenseFetcher : PackageGuard.Core.IFetchLicense
+    {
+        public UrlLicenseFetcher(Microsoft.Extensions.Logging.ILogger logger) { }
+        public System.Threading.Tasks.Task FetchLicenseAsync(PackageGuard.Core.PackageInfo package) { }
     }
 }

--- a/Src/PackageGuard.Core/CSharpProjectAnalyzer.cs
+++ b/Src/PackageGuard.Core/CSharpProjectAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NuGet.ProjectModel;
+using PackageGuard.Core.Common;
 using Pathy;
 
 namespace PackageGuard.Core;

--- a/Src/PackageGuard.Core/CSharpProjectScanner.cs
+++ b/Src/PackageGuard.Core/CSharpProjectScanner.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Build.Construction;
 using Microsoft.Extensions.Logging;
+using PackageGuard.Core.Common;
 using Pathy;
 
 namespace PackageGuard.Core;

--- a/Src/PackageGuard.Core/Common/LoggerExtensions.cs
+++ b/Src/PackageGuard.Core/Common/LoggerExtensions.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 
-namespace PackageGuard.Core;
+namespace PackageGuard.Core.Common;
 
 internal static class LoggerExtensions
 {

--- a/Src/PackageGuard.Core/FetchingStrategies/GitHubLicenseFetcher.cs
+++ b/Src/PackageGuard.Core/FetchingStrategies/GitHubLicenseFetcher.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace PackageGuard.Core.FetchingStrategies;
+
+/// <summary>
+/// Fetches licenses using GitHub metadata.
+/// </summary>
+public class GitHubLicenseFetcher : IFetchLicense
+{
+    private static readonly HttpClient HttpClient = new();
+
+    static GitHubLicenseFetcher()
+    {
+        HttpClient.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("PackageGuard", "v1"));
+    }
+
+    public async Task FetchLicenseAsync(PackageInfo package)
+    {
+        if (package.RepositoryUrl is not null)
+        {
+            string? url = GetGitHubLicenseUrl(package.RepositoryUrl);
+
+            if (url is not null)
+            {
+                string licenseJson = await HttpClient.GetStringAsync(url);
+
+                using JsonDocument doc = JsonDocument.Parse(licenseJson);
+                package.License = doc.RootElement.GetProperty("license").GetProperty("spdx_id").GetString();
+
+                if (package.License?.Equals("noassertion", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    package.License = null;
+                }
+            }
+        }
+    }
+
+    private string? GetGitHubLicenseUrl(string repositoryUrl)
+    {
+        string? url = null;
+
+        const string validCharacters = "[a-zA-Z0-9._-]";
+
+        var match = Regex.Match(repositoryUrl,
+            $@"raw.githubusercontent.com\/(?<owner>{validCharacters}+?)\/(?<repo>{validCharacters}+)");
+
+        if (match.Length == 0)
+        {
+            match = Regex.Match(repositoryUrl,
+                $@"github.com\/(?<owner>{validCharacters}+?)\/(?<repo>{validCharacters}+)");
+        }
+
+        if (match.Length > 0)
+        {
+            string owner = match.Groups["owner"].Value;
+            string repo = match.Groups["repo"].Value;
+
+            url = $"https://api.github.com/repos/{owner}/{repo}/license";
+        }
+
+        return url;
+    }
+}

--- a/Src/PackageGuard.Core/FetchingStrategies/IFetchLicense.cs
+++ b/Src/PackageGuard.Core/FetchingStrategies/IFetchLicense.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace PackageGuard.Core;
+
+/// <summary>
+/// Represents a strategy for fetching a license for a package.
+/// </summary>
+public interface IFetchLicense
+{
+    Task FetchLicenseAsync(PackageInfo package);
+}

--- a/Src/PackageGuard.Core/FetchingStrategies/UrlLicenseFetcher.cs
+++ b/Src/PackageGuard.Core/FetchingStrategies/UrlLicenseFetcher.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Logging;
+
+namespace PackageGuard.Core.FetchingStrategies;
+
+/// <summary>
+/// Fetches licenses using a license URL.
+/// </summary>
+public class UrlLicenseFetcher(ILogger logger) : IFetchLicense
+{
+    private static readonly HttpClient HttpClient = new();
+
+    public async Task FetchLicenseAsync(PackageInfo package)
+    {
+        package.License = "Unknown";
+
+        if (package.LicenseUrl is { Length: > 0 })
+        {
+            try
+            {
+                string licenseText = await HttpClient.GetStringAsync(package.LicenseUrl);
+
+                if (licenseText.Contains("MIT license", StringComparison.OrdinalIgnoreCase))
+                {
+                    package.License = "MIT";
+                }
+                else if (licenseText.Contains("Apache License", StringComparison.OrdinalIgnoreCase))
+                {
+                    package.License = "Apache-2.0";
+                }
+                else if (licenseText.Contains("GNU General Public License", StringComparison.OrdinalIgnoreCase))
+                {
+                    package.License = "GPL-3.0";
+                }
+                else if (licenseText.Contains("MICROSOFT SOFTWARE LICENSE TERMS", StringComparison.OrdinalIgnoreCase))
+                {
+                    package.License = "Microsoft .NET Library License";
+                }
+                else
+                {
+                    logger.LogWarning("Did not detect any well-known licenses in {URL}", package.LicenseUrl);
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogWarning("Failed to extract the license from URL {URL}: {ErrorCode}", package.LicenseUrl, ex.Message);
+            }
+        }
+    }
+}

--- a/Src/PackageGuard.Core/LicenseFetcher.cs
+++ b/Src/PackageGuard.Core/LicenseFetcher.cs
@@ -1,7 +1,5 @@
-using System.Net.Http.Headers;
-using System.Text.Json;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using PackageGuard.Core.FetchingStrategies;
 
 namespace PackageGuard.Core;
 
@@ -10,109 +8,34 @@ namespace PackageGuard.Core;
 /// </summary>
 public sealed class LicenseFetcher(ILogger logger)
 {
-    private static readonly HttpClient HttpClient = new();
-
-    static LicenseFetcher()
-    {
-        HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PackageGuard", "v1"));
-    }
+    private readonly IEnumerable<IFetchLicense> fetchers =
+    [
+        new GitHubLicenseFetcher(),
+        new UrlLicenseFetcher(logger)
+    ];
 
     public async Task AmendWithMissingLicenseInformation(PackageInfo package)
     {
+        if (package.License is not null)
+        {
+            logger.LogInformation("Package {Name} already has a license: {License}", package.Id, package.License);
+            return;
+        }
+
+        foreach (IFetchLicense fetcher in fetchers)
+        {
+            await fetcher.FetchLicenseAsync(package);
+
+            if (package.License is not null)
+            {
+                logger.LogInformation("License found for {Name}: {License}", package.Id, package.License);
+                break;
+            }
+        }
+
         if (package.License is null)
         {
-            logger.LogInformation("Package {Name} {Version} does not have a license. Fetching it separately",
-                package.Id, package.Version);
-
-            await TryFetchLicenseFromGitHubMetaData(package);
-        }
-
-        if (package.License is null)
-        {
-            await TryFetchLicenseFromDownloadUrl(package);
-        }
-
-        logger.LogInformation("Determined the license to be {License}", package.License);
-    }
-
-    private async Task TryFetchLicenseFromGitHubMetaData(PackageInfo package)
-    {
-        if (package.RepositoryUrl is not null)
-        {
-            string? url = GetGitHubLicenseUrl(package.RepositoryUrl);
-
-            if (url is not null)
-            {
-                string licenseJson = await HttpClient.GetStringAsync(url);
-
-                using JsonDocument doc = JsonDocument.Parse(licenseJson);
-                package.License = doc.RootElement.GetProperty("license").GetProperty("spdx_id").GetString();
-
-                if (package.License?.Equals("noassertion", StringComparison.OrdinalIgnoreCase) == true)
-                {
-                    package.License = null;
-                }
-            }
-        }
-    }
-
-    private string? GetGitHubLicenseUrl(string repositoryUrl)
-    {
-        string? url = null;
-
-        const string validCharacters = "[a-zA-Z0-9._-]";
-
-        var match = Regex.Match(repositoryUrl,
-            $@"raw.githubusercontent.com\/(?<owner>{validCharacters}+?)\/(?<repo>{validCharacters}+)");
-
-        if (match.Length == 0)
-        {
-            match = Regex.Match(repositoryUrl,
-                $@"github.com\/(?<owner>{validCharacters}+?)\/(?<repo>{validCharacters}+)");
-        }
-
-        if (match.Length > 0)
-        {
-            string owner = match.Groups["owner"].Value;
-            string repo = match.Groups["repo"].Value;
-
-            url = $"https://api.github.com/repos/{owner}/{repo}/license";
-        }
-
-        return url;
-    }
-
-    private async Task TryFetchLicenseFromDownloadUrl(PackageInfo package)
-    {
-        package.License = "Unknown";
-
-        if (package.LicenseUrl is { Length: > 0 })
-        {
-            try
-            {
-                string licenseText = await HttpClient.GetStringAsync(package.LicenseUrl);
-
-                if (licenseText.Contains("MIT license", StringComparison.OrdinalIgnoreCase))
-                {
-                    package.License = "MIT";
-                }
-                else if (licenseText.Contains("Apache License", StringComparison.OrdinalIgnoreCase))
-                {
-                    package.License = "Apache-2.0";
-                }
-                else if (licenseText.Contains("GNU General Public License", StringComparison.OrdinalIgnoreCase))
-                {
-                    package.License = "GPL-3.0";
-                }
-                else
-                {
-                    logger.LogWarning("Did not detect any well-known licenses in {URL}", package.LicenseUrl);
-                }
-            }
-            catch (HttpRequestException ex)
-            {
-                logger.LogWarning("Failed to extract the license from URL {URL}: {ErrorCode}", package.LicenseUrl, ex.Message);
-            }
+            logger.LogWarning("Unable to determine license for package {Name} {Version}", package.Id, package.Version);
         }
     }
 }

--- a/Src/PackageGuard.Specs/LicenseFetcherSpecs.cs
+++ b/Src/PackageGuard.Specs/LicenseFetcherSpecs.cs
@@ -66,4 +66,4 @@ public class LicenseFetcherSpecs
         // Assert
         package.License.Should().Be("Unknown");
     }
-}
+ }

--- a/Src/PackageGuard.Specs/NuGetPackageAnalyzerSpecs.cs
+++ b/Src/PackageGuard.Specs/NuGetPackageAnalyzerSpecs.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet.Versioning;
+using PackageGuard.Core;
+using Pathy;
+
+namespace PackageGuard.Specs;
+
+[TestClass]
+public class NuGetPackageAnalyzerSpecs
+{
+    private readonly NullLogger nullLogger = NullLogger.Instance;
+
+    [TestMethod]
+    [DataRow("Microsoft.AspNet.WebApi.Client", "6.0.0")]
+    [DataRow("Microsoft.AspNet.WebApi.Core", "5.3.0")]
+    [DataRow("Microsoft.AspNet.WebApi.WebHost", "5.3.0")]
+    [DataRow("Microsoft.AspNet.WebApi.Owin", "5.3.0")]
+    [DataRow("Microsoft.AspNet.WebApi.OwinSelfHost", "5.3.0")]
+    public async Task Can_understand_microsoft_aspnet_libraries(string name, string version)
+    {
+        // Arrange
+        var analyzer = new NuGetPackageAnalyzer(nullLogger, new LicenseFetcher(nullLogger));
+        var packages = new PackageInfoCollection();
+
+        // Act
+        await analyzer.CollectPackageMetadata(ChainablePath.Current.Parent.Parent, name, NuGetVersion.Parse(version), packages);
+
+        // Assert
+        packages.Should().ContainSingle(x => x.License == "Microsoft .NET Library License");
+    }
+}

--- a/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
+++ b/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
@@ -16,7 +16,6 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Meziantou.Extensions.Logging.InMemory" Version="1.2.6" />
-      <PackageReference Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.13" />
       <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.6.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
       <PackageReference Include="MSTest" Version="3.9.3" />
@@ -24,7 +23,6 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
       </ItemGroup>
 
     <ItemGroup>

--- a/Src/PackageGuard.Specs/TestCases/SimpleApp/SimpleApp.csproj
+++ b/Src/PackageGuard.Specs/TestCases/SimpleApp/SimpleApp.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR introduces changes to improve license detection for certain Microsoft packages and refactors the license-fetching functionality. A new interface, `IFetchLicense`, and two implementations, `GitHubLicenseFetcher` and `UrlLicenseFetcher`, are created to handle license retrieval using different strategies. These implementations are combined into a cohesive pipeline within the `LicenseFetcher` class to fetch licenses more efficiently and modularly. Additionally, there is now explicit support for proprietary Microsoft package licenses, such as the "Microsoft .NET Library License". Various cleanups and namespace adjustments were also made to simplify and organize the codebase.

Resolves #40 