### PR TITLE
Fix version and readme

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -30,6 +30,7 @@
         "Compile",
         "Default",
         "Pack",
+        "PreparePackageReadme",
         "Push",
         "RunPackageGuard",
         "RunTests"

--- a/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/your-user-name/my-package")]
-namespace PackageGuard.Core
+﻿namespace PackageGuard.Core
 {
     public class AllowList : PackageGuard.Core.PackagePolicy
     {

--- a/Src/PackageGuard.Core/PackageGuard.Core.csproj
+++ b/Src/PackageGuard.Core/PackageGuard.Core.csproj
@@ -11,30 +11,10 @@
         <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>PackageGuard.Core</AssemblyName>
         <RootNamespace>PackageGuard.Core</RootNamespace>
+        <Authors>Dennis Doomen</Authors>
+        <Copyright>Copyright 2025 Dennis Doomen</Copyright>
     </PropertyGroup>
 
-  <PropertyGroup Label="Package info">
-    <Authors>You're name</Authors>
-    <PackageDescription>
-      A nice description of your package as you want to see it on NuGet.
-    </PackageDescription>
-    <PackageProjectUrl>https://url-to-your-landing-page</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/your-user-name/my-package</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>some;tags;you;like</PackageTags>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageIcon>PackageIcon.png</PackageIcon>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>https://github.com/your-user-name/my-package/releases</PackageReleaseNotes>
-    <Copyright>Copyright 2025-$([System.DateTime]::Now.ToString(yyyy)) Your Name</Copyright>
-  </PropertyGroup>
-
-  <ItemGroup Label="Package files">
-    <None Include="..\PackageIcon.png" Pack="true" Visible="false" PackagePath="" />
-    <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
-    <None Include="..\..\README.md" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.9.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />

--- a/Src/PackageGuard/PackageGuard.csproj
+++ b/Src/PackageGuard/PackageGuard.csproj
@@ -18,8 +18,10 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>nuget;tooling;licenses;versioning</PackageTags>
         <PackageIcon>PackageIcon.png</PackageIcon>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>Readme.md</PackageReadmeFile>
         <PackageReleaseNotes>https://github.com/dennisdoomen/packageguard/releases</PackageReleaseNotes>
-        <Copyright>Copyright 2025-$([System.DateTime]::Now.ToString(yyyy)) Dennis Doomen</Copyright>
+        <Copyright>Copyright 2025 Dennis Doomen</Copyright>
     </PropertyGroup>
 
     <ItemGroup>
@@ -46,6 +48,7 @@
 
   <ItemGroup Label="Package files">
     <None Include="..\PackageIcon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="..\..\Artifacts\Readme.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. A new build target, `PreparePackageReadme`, generates a filtered `Readme.md` file using specific sections from the repository's README. It ensures that only relevant parts are included in the final package.
2. Assembly versions, including Semantic Versioning (SemVer), are now explicitly set during the `DotNetBuild` task, improving version control.
4. The `PackageGuard` project now declares the `Readme.md` in the package metadata, ensures license compliance with an MIT license expression, and includes the generated `Readme.md` in the package contents.
