### PR TITLE
Add support for denying prerelease packages via configuration

### DIFF
--- a/Samples/config.json
+++ b/Samples/config.json
@@ -1,6 +1,7 @@
 {
     "settings": {
         "allow": {
+            "prerelease": false,
             "licenses": [
                 "Apache-2.0",
                 "MIT"
@@ -10,6 +11,7 @@
             ]
         },
         "deny": {
+            "prerelease": true,
             "licenses": [],
             "packages": [
                 "moq"

--- a/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -4,6 +4,7 @@
     {
         public AllowList() { }
         public System.Collections.Generic.List<string> Feeds { get; set; }
+        public bool Prerelease { get; set; }
     }
     public class CSharpProjectAnalyzer
     {
@@ -29,6 +30,7 @@
     public class DenyList : PackageGuard.Core.PackagePolicy
     {
         public DenyList() { }
+        public bool Prerelease { get; set; }
     }
     public class DotNetLockFileLoader
     {

--- a/Src/PackageGuard.Core/DenyList.cs
+++ b/Src/PackageGuard.Core/DenyList.cs
@@ -1,12 +1,25 @@
-﻿namespace PackageGuard.Core;
+﻿using NuGet.Versioning;
+
+namespace PackageGuard.Core;
 
 public class DenyList : PackagePolicy
 {
+    /// <summary>
+    /// Gets or sets a value indicating whether to deny all prerelease packages regardless of package name.
+    /// </summary>
+    public bool Prerelease { get; set; }
+
     /// <summary>
     /// Determines if the given package is denied by the licenses or packages defined in this deny list.
     /// </summary>
     internal bool Denies(PackageInfo package)
     {
+        // Check if prerelease packages are denied
+        if (Prerelease && NuGetVersion.Parse(package.Version).IsPrerelease)
+        {
+            return true;
+        }
+
         if (Licenses.Any() && Licenses.Contains(package.License!, StringComparer.OrdinalIgnoreCase))
         {
             return true;

--- a/Src/PackageGuard.Specs/CSharpProjectAnalyzerSpecs.cs
+++ b/Src/PackageGuard.Specs/CSharpProjectAnalyzerSpecs.cs
@@ -473,6 +473,94 @@ public class CSharpProjectAnalyzerSpecs
     }
 
     [TestMethod]
+    public async Task Can_allow_prerelease_packages()
+    {
+        // Arrange
+        var analyzer =
+            new CSharpProjectAnalyzer(cSharpProjectScanner, nuGetPackageAnalyzer)
+            {
+                ForceRestore = true,
+                ProjectPath = ChainablePath.Current / "TestCases" / "Prerelease" / "SimpleApp.csproj",
+                AllowList = new AllowList
+                {
+                    Licenses = ["mit", "Apache-2.0", "Microsoft .NET Library License"],
+                    Prerelease = true,
+                },
+            };
+
+        // Act
+        var violations = await analyzer.ExecuteAnalysis();
+
+        // Assert
+        violations.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Can_deny_prerelease_packages_using_an_allow_clause()
+    {
+        // Arrange
+        var analyzer =
+            new CSharpProjectAnalyzer(cSharpProjectScanner, nuGetPackageAnalyzer)
+            {
+                ForceRestore = true,
+                ProjectPath = ChainablePath.Current / "TestCases" / "Prerelease" / "SimpleApp.csproj",
+                AllowList = new AllowList
+                {
+                    Licenses = ["mit", "Apache-2.0", "Microsoft .NET Library License"],
+                    Prerelease = false,
+                },
+            };
+
+        // Act
+        var violations = await analyzer.ExecuteAnalysis();
+
+        // Assert
+        violations.Should().ContainEquivalentOf(new
+        {
+            PackageId = "FluentAssertions"
+        });
+
+        violations.Should().ContainEquivalentOf(new
+        {
+            PackageId = "System.CommandLine"
+        });
+    }
+
+    [TestMethod]
+    public async Task Can_deny_prerelease_packages_using_a_deny_clause()
+    {
+        // Arrange
+        var analyzer =
+            new CSharpProjectAnalyzer(cSharpProjectScanner, nuGetPackageAnalyzer)
+            {
+                ForceRestore = true,
+                ProjectPath = ChainablePath.Current / "TestCases" / "Prerelease" / "SimpleApp.csproj",
+                AllowList = new AllowList
+                {
+                    Licenses = ["mit", "Apache-2.0", "Microsoft .NET Library License"],
+                },
+                DenyList = new DenyList
+                {
+                    Prerelease = true,
+                }
+            };
+
+        // Act
+        var violations = await analyzer.ExecuteAnalysis();
+
+        // Assert
+        violations.Should().ContainEquivalentOf(new
+        {
+            PackageId = "FluentAssertions"
+        });
+
+        violations.Should().ContainEquivalentOf(new
+        {
+            PackageId = "System.CommandLine"
+        });
+    }
+
+    [TestMethod]
     public async Task Can_exclude_an_entire_feed()
     {
         // Arrange

--- a/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
+++ b/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
@@ -46,9 +46,19 @@
       <None Include="TestCases\UnreachableFeed\Program.cs">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <Compile Remove="TestCases\Prerelease\UnitTest1.cs" />
+      <None Include="TestCases\Prerelease\UnitTest1.cs">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>
+      <None Include="TestCases\Prerelease\SimpleApp.csproj">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Include="TestCases\Prerelease\SimpleApp.sln">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
       <Content Include="TestCases\SimpleApp\SimpleApp.csproj">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>

--- a/Src/PackageGuard.Specs/TestCases/Prerelease/SimpleApp.csproj
+++ b/Src/PackageGuard.Specs/TestCases/Prerelease/SimpleApp.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" version="7.0.0-alpha.6"/>
+    <PackageReference Include="System.CommandLine" version="0.3.0-alpha.20054.1"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Src/PackageGuard.Specs/TestCases/Prerelease/SimpleApp.sln
+++ b/Src/PackageGuard.Specs/TestCases/Prerelease/SimpleApp.sln
@@ -1,0 +1,14 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Src/PackageGuard.Specs/TestCases/Prerelease/UnitTest1.cs
+++ b/Src/PackageGuard.Specs/TestCases/Prerelease/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace SimpleApp;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}

--- a/Src/PackageGuard/ConfigurationLoader.cs
+++ b/Src/PackageGuard/ConfigurationLoader.cs
@@ -24,6 +24,7 @@ public static class ConfigurationLoader
 
         analyzer.AllowList.Licenses.AddRange(globalSettings.Allow.Licenses);
         analyzer.AllowList.Feeds.AddRange(globalSettings.Allow.Feeds);
+        analyzer.AllowList.Prerelease = globalSettings.Allow.Prerelease;
 
         foreach (string package in globalSettings.Deny.Packages)
         {
@@ -33,6 +34,7 @@ public static class ConfigurationLoader
         }
 
         analyzer.DenyList.Licenses.AddRange(globalSettings.Deny.Licenses);
+        analyzer.DenyList.Prerelease = globalSettings.Deny.Prerelease;
 
         analyzer.IgnoredFeeds = globalSettings.IgnoredFeeds;
     }

--- a/Src/PackageGuard/GlobalSettings.cs
+++ b/Src/PackageGuard/GlobalSettings.cs
@@ -8,7 +8,7 @@ public class GlobalSettings
     public AllowPolicyItem Allow { get; set; } = new();
 
     [UsedImplicitly]
-    public PolicyItem Deny { get; set; } = new();
+    public DenyPolicyItem Deny { get; set; } = new();
 
     [UsedImplicitly]
     public string[] IgnoredFeeds { get; set; } = [];
@@ -26,5 +26,14 @@ public class GlobalSettings
     {
         [UsedImplicitly]
         public string[] Feeds { get; set; } = [];
+
+        [UsedImplicitly]
+        public bool Prerelease { get; set; } = true;
+    }
+
+    public class DenyPolicyItem : PolicyItem
+    {
+        [UsedImplicitly]
+        public bool Prerelease { get; set; }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to manage pre-release package handling in `PackageGuard`, along with updates to documentation, configuration, and tests. The most significant changes include adding `Prerelease` properties to both allow and deny lists, updating the logic to enforce these rules, and enhancing the documentation and test cases to reflect this new functionality.

### New Feature: Pre-release Package Handling

* **Core Logic Updates**:
  - Added `Prerelease` properties to the `AllowList` and `DenyList` classes to specify whether pre-release packages are allowed or denied. (`Src/PackageGuard.Core/AllowList.cs`, [[1]](diffhunk://#diff-83f635424e5d97ddead9bdef013b0e1e0afac0c15814c2b4d6700dce444f2a05R15-R33); `Src/PackageGuard.Core/DenyList.cs`, [[2]](diffhunk://#diff-0c314257a58cf2ee00e07848b7932235abbc1a03e03b16f39c4878cd3ce7829fL1-R22)
  - Updated the `Allows` and `Denies` methods to incorporate the `Prerelease` property when evaluating packages. (`Src/PackageGuard.Core/AllowList.cs`, [[1]](diffhunk://#diff-83f635424e5d97ddead9bdef013b0e1e0afac0c15814c2b4d6700dce444f2a05L46-R57); `Src/PackageGuard.Core/DenyList.cs`, [[2]](diffhunk://#diff-0c314257a58cf2ee00e07848b7932235abbc1a03e03b16f39c4878cd3ce7829fL1-R22)

* **Configuration Updates**:
  - Added `prerelease` support to the JSON configuration file under both `allow` and `deny` sections. (`Samples/config.json`, [[1]](diffhunk://#diff-bff3db9ad8363d4a1e9a0221678134fa37d3e4f31d509ca67c9cf68ea4d257d7R4) [[2]](diffhunk://#diff-bff3db9ad8363d4a1e9a0221678134fa37d3e4f31d509ca67c9cf68ea4d257d7R14)
  - Updated the `ConfigurationLoader` to parse and apply the `prerelease` settings. (`Src/PackageGuard/ConfigurationLoader.cs`, [[1]](diffhunk://#diff-53d7a4c6fcfddc6a297b15bdd46998c8c905adf0ad4eaaa7c92cf4aacc688065R27) [[2]](diffhunk://#diff-53d7a4c6fcfddc6a297b15bdd46998c8c905adf0ad4eaaa7c92cf4aacc688065R37)

### Documentation Enhancements

* Updated the `README.md` to explain how to configure and use the new `prerelease` option in both the allow and deny lists. This includes examples and clarification of precedence rules. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R94) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L105-R115) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L124-R138)

These changes collectively enhance `PackageGuard` by providing more granular control over pre-release package management, improving usability, and ensuring robust test coverage.