### PR TITLE
Ensured caching doesn't bring back old violations

### DIFF
--- a/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -57,6 +57,8 @@
     public class PackageInfo : MemoryPack.IMemoryPackFormatterRegister, MemoryPack.IMemoryPackable<PackageGuard.Core.PackageInfo>
     {
         public PackageInfo() { }
+        [MemoryPack.MemoryPackIgnore]
+        public bool IsUsed { get; set; }
         public string? License { get; set; }
         public string? LicenseUrl { get; set; }
         public string Name { get; set; }
@@ -65,6 +67,7 @@
         public string Source { get; set; }
         public string SourceUrl { get; set; }
         public string Version { get; set; }
+        public void MarkAsUsed() { }
         public bool MatchesFeed(string feedWildcard) { }
         public bool SatisfiesRange(string name, string? versionRange = null) { }
         public override string ToString() { }

--- a/Src/PackageGuard.Core/CSharpProjectAnalyzer.cs
+++ b/Src/PackageGuard.Core/CSharpProjectAnalyzer.cs
@@ -20,7 +20,7 @@ public class CSharpProjectAnalyzer(CSharpProjectScanner scanner, NuGetPackageAna
     public string ProjectPath { get; set; } = string.Empty;
 
     /// <summary>
-    /// If specified, a list of packages, versions and licenses that are allowed. Everything else is forbidden.
+    /// If specified, a list of packages, versions, and licenses that are allowed. Everything else is forbidden.
     /// </summary>
     /// <remarks>
     /// Can be overridden by <see cref="DenyList"/>
@@ -28,7 +28,7 @@ public class CSharpProjectAnalyzer(CSharpProjectScanner scanner, NuGetPackageAna
     public AllowList AllowList { get; set; } = new();
 
     /// <summary>
-    /// If specified, a list of packages, versions and licenses that are forbidden, even if it was listed in <see cref="AllowList"/>.
+    /// If specified, a list of packages, versions, and licenses that are forbidden, even if it was listed in <see cref="AllowList"/>.
     /// </summary>
     public DenyList DenyList { get; set; } = new();
 

--- a/Src/PackageGuard.Core/PackageInfo.cs
+++ b/Src/PackageGuard.Core/PackageInfo.cs
@@ -16,6 +16,16 @@ public partial class PackageInfo
     public string? License { get; set; }
     public string? LicenseUrl { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the package was used in any of the
+    /// projects during this run.
+    /// </summary>
+    /// <remarks>
+    /// It is used to clear out old package information before updating the persisted cache.
+    /// </remarks>
+    [MemoryPackIgnore]
+    public bool IsUsed { get; set; }
+
     public string[] Projects
     {
         get => projects.ToArray();
@@ -64,5 +74,13 @@ public partial class PackageInfo
     public bool MatchesFeed(string feedWildcard)
     {
         return Source.MatchesWildcard(feedWildcard) || SourceUrl.MatchesWildcard(feedWildcard);
+    }
+
+    /// <summary>
+    /// Marks the current package as being used by the current projects.
+    /// </summary>
+    public void MarkAsUsed()
+    {
+        IsUsed = true;
     }
 }


### PR DESCRIPTION
This PR introduces a usage marker to packages, adding an IsUsed flag and a MarkAsUsed method. The collection now keeps a separate in-memory cache of previously seen packages, uses it to resolve license info and lookups, and marks packages as used when they’re added or found from valid sources. When persisting the cache, it writes only packages marked as used, preventing stale entries from reappearing and eliminating old violations resurrected by caching. It also includes minor documentation punctuation fixes and makes the in-memory set readonly.
