### PR TITLE
Allow ignoring violations when invoking PackageGuard

### DIFF
--- a/Src/PackageGuard/AnalyzeCommand.cs
+++ b/Src/PackageGuard/AnalyzeCommand.cs
@@ -10,6 +10,9 @@ namespace PackageGuard;
 [UsedImplicitly]
 internal sealed class AnalyzeCommand(ILogger logger) : AsyncCommand<AnalyzeCommandSettings>
 {
+    private const int SuccessExitCode = 0;
+    private const int FailureExitCode = 1;
+
     public override async Task<int> ExecuteAsync(CommandContext context, AnalyzeCommandSettings settings)
     {
         // Display PackageGuard version
@@ -78,11 +81,11 @@ internal sealed class AnalyzeCommand(ILogger logger) : AsyncCommand<AnalyzeComma
                 AnsiConsole.MarkupLine("");
             }
 
-            return 1;
+            return settings.IgnoreViolations ? SuccessExitCode : FailureExitCode;
         }
 
         AnsiConsole.MarkupLine("[green3_1]No policy violations found.[/]");
 
-        return 0;
+        return SuccessExitCode;
     }
 }

--- a/Src/PackageGuard/AnalyzeCommandSettings.cs
+++ b/Src/PackageGuard/AnalyzeCommandSettings.cs
@@ -23,6 +23,10 @@ internal class AnalyzeCommandSettings : CommandSettings
     [CommandOption("-i|--restore-interactive|--restoreinteractive")]
     public bool Interactive {get; set;} = true;
 
+    [Description("Don't fail the analysis if any violations are found. Defaults to false.")]
+    [CommandOption("--ignore-violations|--ignoreviolations|--ignore")]
+    public bool IgnoreViolations {get; set;} = false;
+
     [Description("Force restoring the NuGet dependencies, even if the lockfile is up-to-date")]
     [CommandOption("-f|--force-restore|--forcerestore")]
     public bool ForceRestore { get; set; } = false;


### PR DESCRIPTION
This PR adds an option to let the analysis succeed even when violations are found. A new boolean setting `IgnoreViolations` (default `false`) is exposed via `--ignore-violations`, `--ignoreviolations`, and `--ignore`. When violations exist, the command now exits with success if `IgnoreViolations` is set; otherwise it returns a failure code. 

Exit codes are centralized through `SuccessExitCode` (0) and `FailureExitCode` (1), and success is always returned when no violations are found.

Closes #29 