### PR TITLE
Optimize Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,22 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "16:00"
-      timezone: "Europe/Copenhagen"
+    groups:
+      all-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "16:00"
-      timezone: "Europe/Copenhagen"
+    groups:
+      minor-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    


### PR DESCRIPTION
This pull request updates the Dependabot configuration to group dependency updates, making it easier to manage and review updates in batches rather than individually.

Dependabot configuration improvements:

* Added grouping for GitHub Actions updates under the `all-actions` group, which will group all version updates together for this ecosystem. (.github/dependabot.yml)
* Added grouping for NuGet updates under the `minor-dependencies` group, which will group all minor and patch version updates together for this ecosystem. (.github/dependabot.yml)