### PR TITLE
Exclude dependabot PRs from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,7 +2,9 @@ changelog:
   exclude:
     labels:
       - changelog-ignore
-    authors: [ ]
+    authors:
+      - dependabot
+      - dependabot[bot]
   categories:
     - title: Breaking Changes
       labels:


### PR DESCRIPTION
Adds \dependabot\ and \dependabot[bot]\ to the \xclude.authors\ list in \.github/release.yml\ so Dependabot bump PRs are omitted from generated release notes.