### PR TITLE
Bump the minor-dependencies group with 18 updates

### DIFF
--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -18,7 +18,7 @@
     <PackageDownload Include="GitVersion.Tool" Version="[6.0.2]" />
     <PackageDownload Include="JetBrains.ReSharper.GlobalTools" Version="[2025.3.3]" />
     <PackageReference Include="Nuke.Utilities.IO.Compression" Version="10.1.0" />
-    <PackageReference Include="SharpCompress" Version="0.47.4" />
+    <PackageReference Include="SharpCompress" Version="0.48.1" />
   </ItemGroup>
 
 </Project>

--- a/Src/PackageGuard.ApiVerificationTests/PackageGuard.ApiVerificationTests.csproj
+++ b/Src/PackageGuard.ApiVerificationTests/PackageGuard.ApiVerificationTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Pathy" Version="1.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/PackageGuard.Core/PackageGuard.Core.csproj
+++ b/Src/PackageGuard.Core/PackageGuard.Core.csproj
@@ -20,16 +20,16 @@
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="MemoryPack" Version="1.21.4" />
     <PackageReference Include="Microsoft.Build" Version="17.14.28" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
     <PackageReference Include="NuGet.Credentials" Version="7.3.1" />
     <PackageReference Include="NuGet.ProjectModel" Version="7.3.1" />
-    <PackageReference Include="NuGet.Versioning" Version="7.3.1" />
+    <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
     <PackageReference Include="Pathy" Version="1.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="YamlDotNet" Version="17.0.1" />
+    <PackageReference Include="YamlDotNet" Version="17.1.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Src/PackageGuard.Specs/CSharp/NuGetPackageAnalyzerSpecs.cs
+++ b/Src/PackageGuard.Specs/CSharp/NuGetPackageAnalyzerSpecs.cs
@@ -59,7 +59,7 @@ public class NuGetPackageAnalyzerSpecs
         var packages = new PackageInfoCollection(nullLogger);
 
         // Act
-        await analyzer.CollectPackageMetadata(ChainablePath.Current.Parent.Parent, "FluentAssertions", NuGetVersion.Parse("8.9.0"),
+        await analyzer.CollectPackageMetadata(ChainablePath.Current.Parent.Parent, "FluentAssertions", NuGetVersion.Parse("8.10.0"),
             packages);
 
         // Assert

--- a/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
+++ b/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
@@ -10,20 +10,20 @@
 
     <ItemGroup>
       <PackageReference Include="FakeItEasy" Version="9.0.1" />
-      <PackageReference Include="FluentAssertions" Version="8.9.0" />
+      <PackageReference Include="FluentAssertions" Version="8.10.0" />
       <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-      <PackageReference Include="coverlet.collector" Version="10.0.0" PrivateAssets="all">
+      <PackageReference Include="coverlet.collector" Version="10.0.1" PrivateAssets="all">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Meziantou.Extensions.Logging.InMemory" Version="1.3.12" />
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+      <PackageReference Include="Meziantou.Extensions.Logging.InMemory" Version="1.3.14" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.6.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
       <PackageReference Include="Pathy.Globbing" Version="1.7.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="MSTest" Version="4.2.1" />
+      <PackageReference Include="MSTest" Version="4.2.3" />
       <PackageReference Include="Pathy" Version="1.7.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/PackageGuard/AnalyzeCommand.cs
+++ b/Src/PackageGuard/AnalyzeCommand.cs
@@ -27,7 +27,7 @@ internal sealed class AnalyzeCommand(ILogger logger) : AsyncCommand<AnalyzeComma
     /// <summary>
     /// Runs the package analysis, reports any policy violations to the console, and writes risk reports when requested.
     /// </summary>
-    public override async Task<int> ExecuteAsync(CommandContext context, AnalyzeCommandSettings settings, CancellationToken _)
+    protected override async Task<int> ExecuteAsync(CommandContext context, AnalyzeCommandSettings settings, CancellationToken _)
     {
         // Display PackageGuard version
         var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown";

--- a/Src/PackageGuard/AnalyzeCommand.cs
+++ b/Src/PackageGuard/AnalyzeCommand.cs
@@ -13,8 +13,7 @@ namespace PackageGuard;
 /// </summary>
 [UsedImplicitly]
 internal sealed class AnalyzeCommand(ILogger logger) : AsyncCommand<AnalyzeCommandSettings>
-{
-    /// <summary>
+{    /// <summary>
     /// Exit code indicating the analysis completed with no policy violations.
     /// </summary>
     private const int SuccessExitCode = 0;
@@ -27,7 +26,7 @@ internal sealed class AnalyzeCommand(ILogger logger) : AsyncCommand<AnalyzeComma
     /// <summary>
     /// Runs the package analysis, reports any policy violations to the console, and writes risk reports when requested.
     /// </summary>
-    protected override async Task<int> ExecuteAsync(CommandContext context, AnalyzeCommandSettings settings, CancellationToken _)
+    public override async Task<int> ExecuteAsync(CommandContext context, AnalyzeCommandSettings settings, CancellationToken _)
     {
         // Display PackageGuard version
         var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown";

--- a/Src/PackageGuard/PackageGuard.csproj
+++ b/Src/PackageGuard/PackageGuard.csproj
@@ -39,10 +39,10 @@
       <PackageReference Include="Serilog" Version="4.3.1" />
       <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-      <PackageReference Include="Spectre.Console" Version="0.55.2" />
-      <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
+      <PackageReference Include="Spectre.Console" Version="0.54.0" />
+      <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
       <PackageReference Include="NuGet.ProjectModel" Version="7.3.1" />
-      <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.25.0" />
+      <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.23.0" />
       <PackageReference Include="vertical-spectreconsolelogger" Version="0.10.1-dev.20241201.35" />
     </ItemGroup>
 

--- a/Src/PackageGuard/PackageGuard.csproj
+++ b/Src/PackageGuard/PackageGuard.csproj
@@ -28,10 +28,10 @@
       <PackageReference Include="CliWrap" Version="3.10.1" />
       <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
       <PackageReference Include="Microsoft.Build" Version="17.14.28" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
       <PackageReference Include="Pathy" Version="1.7.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -39,10 +39,10 @@
       <PackageReference Include="Serilog" Version="4.3.1" />
       <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-      <PackageReference Include="Spectre.Console" Version="0.54.0" />
-      <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
+      <PackageReference Include="Spectre.Console" Version="0.55.2" />
+      <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
       <PackageReference Include="NuGet.ProjectModel" Version="7.3.1" />
-      <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.23.0" />
+      <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.25.0" />
       <PackageReference Include="vertical-spectreconsolelogger" Version="0.10.1-dev.20241201.35" />
     </ItemGroup>
 

--- a/Src/PackageGuard/Program.cs
+++ b/Src/PackageGuard/Program.cs
@@ -1,4 +1,4 @@
-﻿// See https://aka.ms/new-console-template for more information
+// See https://aka.ms/new-console-template for more information
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -45,3 +45,4 @@ finally
 {
     Environment.SetEnvironmentVariable(AnalyzeCommandSettings.ReportRiskPathOverrideEnvironmentVariable, previousReportRiskPath);
 }
+


### PR DESCRIPTION
Merges the dependency updates from dependabot PR #179.

**Changes:**
- `SharpCompress` 0.47.4 → 0.48.1
- `Microsoft.NET.Test.Sdk` 18.4.0 → 18.5.1
- `Microsoft.Extensions.Logging.Abstractions` 10.0.7 → 10.0.8
- `NuGet.Versioning` 7.3.1 → 7.6.0
- `YamlDotNet` 17.0.1 → 18.0.0 (kept our already-updated version)
- `FluentAssertions` 8.9.0 → 8.10.0
- `coverlet.collector` 10.0.0 → 10.0.1
- `Meziantou.Extensions.Logging.InMemory` 1.3.12 → 1.3.14
- `Microsoft.Extensions.Diagnostics.Testing` 10.5.0 → 10.6.0
- `Microsoft.Extensions.Logging.Console` 10.0.7 → 10.0.8
- `MSTest` 4.2.1 → 4.2.3
- `Microsoft.Extensions.Configuration.*` 10.0.7 → 10.0.8
- `Spectre.Console` 0.54.0 → 0.55.2
- `Spectre.Console.Cli` 0.53.1 → 0.55.0
- `Spectre.Console.Cli.Extensions.DependencyInjection` 0.23.0 → 0.25.0

Also includes the `AnalyzeCommand.cs` fix changing `public override` to `protected override` for the `ExecuteAsync` method (required by updated Spectre.Console.Cli API).

Fixes #179