### PR TITLE
Fix ILogger output not appearing by registering AddSpectreConsole

### DIFF
--- a/Src/PackageGuard/Program.cs
+++ b/Src/PackageGuard/Program.cs
@@ -6,6 +6,7 @@ using PackageGuard;
 using Serilog;
 using Spectre.Console.Cli;
 using Spectre.Console.Cli.Extensions.DependencyInjection;
+using Vertical.SpectreLogger;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 var services = new ServiceCollection();
@@ -13,7 +14,13 @@ var services = new ServiceCollection();
 services.AddLogging(configure => configure
     .SetMinimumLevel(LogLevel.Debug)
     .AddSerilog()
-);
+    .AddSpectreConsole(b => b
+        .ConfigureProfile(LogLevel.Trace, p => p.OutputTemplate = "[grey35]{Message}{NewLine}{Exception}[/]")
+        .ConfigureProfile(LogLevel.Debug, p => p.OutputTemplate = "[grey46]{Message}{NewLine}{Exception}[/]")
+        .ConfigureProfile(LogLevel.Information, p => p.OutputTemplate = "[grey85]{Message}{NewLine}{Exception}[/]")
+        .ConfigureProfile(LogLevel.Warning, p => p.OutputTemplate = "[gold1]{Message}{NewLine}{Exception}[/]")
+        .ConfigureProfile(LogLevel.Error, p => p.OutputTemplate = "[white on red1]{Message}{NewLine}{Exception}[/]")
+        .SetMinimumLevel(LogLevel.Debug)));
 
 services.AddSingleton<ILogger>(sp => sp
     .GetRequiredService<ILoggerFactory>()


### PR DESCRIPTION
## Summary

`AddSpectreConsole` was missing from the logging pipeline on `main`, causing all `ILogger` calls to be silently discarded — no console output from the logger at all.

The call was present on a feature branch but never made it onto main.

## Test plan

- [ ] Run `dotnet run --project Src/PackageGuard -- .` and verify logger output (startup header, analysis progress, violations) is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)