### PR TITLE
Bump NuGet dependencies

### DIFF
--- a/Src/PackageGuard.ApiVerificationTests/PackageGuard.ApiVerificationTests.csproj
+++ b/Src/PackageGuard.ApiVerificationTests/PackageGuard.ApiVerificationTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Pathy" Version="1.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/PackageGuard.Core/PackageGuard.Core.csproj
+++ b/Src/PackageGuard.Core/PackageGuard.Core.csproj
@@ -16,13 +16,13 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.10.1" />
+    <PackageReference Include="CliWrap" Version="3.10.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="MemoryPack" Version="1.21.4" />
     <PackageReference Include="Microsoft.Build" Version="17.14.28" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
-    <PackageReference Include="NuGet.Credentials" Version="7.3.1" />
-    <PackageReference Include="NuGet.ProjectModel" Version="7.3.1" />
+    <PackageReference Include="NuGet.Credentials" Version="7.6.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="7.6.0" />
     <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
     <PackageReference Include="Pathy" Version="1.7.1">
       <PrivateAssets>all</PrivateAssets>
@@ -32,11 +32,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.16" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
+++ b/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
@@ -16,7 +16,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Meziantou.Extensions.Logging.InMemory" Version="1.3.14" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
       <PackageReference Include="Pathy.Globbing" Version="1.7.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -30,13 +30,13 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.10.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.16" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.7.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.6.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.7.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Src/PackageGuard/PackageGuard.csproj
+++ b/Src/PackageGuard/PackageGuard.csproj
@@ -25,7 +25,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="CliWrap" Version="3.10.1" />
+      <PackageReference Include="CliWrap" Version="3.10.2" />
       <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
       <PackageReference Include="Microsoft.Build" Version="17.14.28" />
       <PackageReference Include="Pathy" Version="1.7.1">
@@ -36,24 +36,24 @@
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
       <PackageReference Include="Spectre.Console" Version="0.54.0" />
       <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
-      <PackageReference Include="NuGet.ProjectModel" Version="7.3.1" />
+      <PackageReference Include="NuGet.ProjectModel" Version="7.6.0" />
       <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.23.0" />
       <PackageReference Include="vertical-spectreconsolelogger" Version="0.10.1-dev.20241201.35" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.16" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.16" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.16" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16" />
-      <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
       <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary

- CliWrap 3.10.1 → 3.10.2
- NuGet.ProjectModel / NuGet.Credentials 7.3.1 → 7.6.0
- Microsoft.Extensions.* → 10.0.9
- Microsoft.Extensions.Diagnostics.Testing → 10.7.0
- Serilog.Extensions.Logging 9.0.2 → 10.0.0
- Microsoft.NET.Test.Sdk 18.5.1 → 18.6.0

## Intentionally skipped

| Package | Reason |
|---|---|
| `Spectre.Console` / `Cli` / `DI` | Known runtime incompatibility with `vertical-spectreconsolelogger` (see 75d7425) |
| `Microsoft.Build` | 18.x dropped the .NET target; stays on 17.14.28 |
| `Verify.DiffPlex` | 3.2.0 has an internal API mismatch with `Verify.Xunit 31.12.5` |

## Test plan

- [x] Solution builds clean
- [x] Unit tests pass (165/167; 2 failures are pre-existing integration tests requiring a GitHub API key)
- [x] API verification snapshot test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)