### PR TITLE
Fix OsvRiskEnricher crashing on network errors and improve exception logging

### DIFF
--- a/Src/PackageGuard.Core/GitHubRepositoryRiskEnricher.cs
+++ b/Src/PackageGuard.Core/GitHubRepositoryRiskEnricher.cs
@@ -271,8 +271,7 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
         }
         catch (Exception ex)
         {
-            logger.LogDebug("Failed to fetch GitHub repository risk metadata from {RepositoryApiRoot}: {Error}",
-                repositoryApiRoot, ex.Message);
+            logger.LogDebug(ex, "Failed to fetch GitHub repository risk metadata from {RepositoryApiRoot}", repositoryApiRoot);
             return null;
         }
     }

--- a/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
+++ b/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
@@ -40,8 +40,7 @@ internal sealed class LicenseUrlRiskEnricher(ILogger logger) : IEnrichPackageRis
         }
         catch (Exception ex)
         {
-            logger.LogDebug("Failed to validate license URL for {Name} {Version}: {Error}",
-                package.Name, package.Version, ex.Message);
+            logger.LogDebug(ex, "Failed to validate license URL for {Name} {Version}", package.Name, package.Version);
             package.HasValidLicenseUrl = false;
             package.HasValidatedLicenseUrl = true;
         }

--- a/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
+++ b/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
@@ -40,7 +40,7 @@ internal sealed class LicenseUrlRiskEnricher(ILogger logger) : IEnrichPackageRis
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "Failed to validate license URL for {Name} {Version}", package.Name, package.Version);
+            logger.LogDebug(ex, "Failed to validate license URL {LicenseUrl} for {Name} {Version}", package.LicenseUrl, package.Name, package.Version);
             package.HasValidLicenseUrl = false;
             package.HasValidatedLicenseUrl = true;
         }

--- a/Src/PackageGuard.Core/OsvRiskEnricher.cs
+++ b/Src/PackageGuard.Core/OsvRiskEnricher.cs
@@ -1,12 +1,13 @@
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 namespace PackageGuard.Core;
 
 /// <summary>
 /// Queries the OSV API for vulnerability data and enriches a <see cref="PackageInfo"/> with the results.
 /// </summary>
-internal sealed class OsvRiskEnricher : IEnrichPackageRisk
+internal sealed class OsvRiskEnricher(ILogger logger) : IEnrichPackageRisk
 {
     /// <summary>
     /// Shared HTTP client used for all OSV API requests.
@@ -44,7 +45,16 @@ internal sealed class OsvRiskEnricher : IEnrichPackageRisk
             }
         }
 
-        OsvPackageRiskResult result = await QueryAsync(package);
+        OsvPackageRiskResult result;
+        try
+        {
+            result = await QueryAsync(package);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to query OSV vulnerability data for {Name} {Version}", package.Name, package.Version);
+            return;
+        }
 
         lock (CacheLock)
         {

--- a/Src/PackageGuard.Core/OsvRiskEnricher.cs
+++ b/Src/PackageGuard.Core/OsvRiskEnricher.cs
@@ -52,7 +52,8 @@ internal sealed class OsvRiskEnricher(ILogger logger) : IEnrichPackageRisk
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to query OSV vulnerability data for {Name} {Version}", package.Name, package.Version);
+            logger.LogWarning(ex, "Failed to query OSV vulnerability data from {OsvApiUrl} for {Name} {Version}",
+                "https://api.osv.dev/v1/query", package.Name, package.Version);
             return;
         }
 

--- a/Src/PackageGuard.Core/ParallelPackageRiskEnricher.cs
+++ b/Src/PackageGuard.Core/ParallelPackageRiskEnricher.cs
@@ -27,7 +27,7 @@ internal sealed class ParallelPackageRiskEnricher
             [
                 new LicenseUrlRiskEnricher(logger),
                 new NuGetPackageSigningRiskEnricher(logger),
-                new OsvRiskEnricher(),
+                new OsvRiskEnricher(logger),
                 new GitHubRepositoryRiskEnricher(logger, gitHubApiKey)
             ])
     {

--- a/Src/PackageGuard.Specs/ParallelPackageRiskEnricherSpecs.cs
+++ b/Src/PackageGuard.Specs/ParallelPackageRiskEnricherSpecs.cs
@@ -36,7 +36,7 @@ public class ParallelPackageRiskEnricherSpecs
     [TestCategory("Integration")]
     public async Task Osv_enricher_should_populate_vulnerability_data_for_a_real_package()
     {
-        var enricher = new OsvRiskEnricher();
+        var enricher = new OsvRiskEnricher(NullLogger.Instance);
         var package = new PackageInfo
         {
             Name = "Newtonsoft.Json",
@@ -91,7 +91,7 @@ public class ParallelPackageRiskEnricherSpecs
     [TestCategory("Integration")]
     public async Task Osv_enricher_should_detect_vulnerabilities_and_fix_data_for_a_known_vulnerable_version()
     {
-        var enricher = new OsvRiskEnricher();
+        var enricher = new OsvRiskEnricher(NullLogger.Instance);
         var package = new PackageInfo
         {
             Name = "Newtonsoft.Json",
@@ -110,7 +110,7 @@ public class ParallelPackageRiskEnricherSpecs
     [TestCategory("Integration")]
     public async Task Osv_enricher_should_query_npm_ecosystem_for_npm_packages()
     {
-        var enricher = new OsvRiskEnricher();
+        var enricher = new OsvRiskEnricher(NullLogger.Instance);
         var package = new PackageInfo
         {
             Name = "lodash",

--- a/Src/PackageGuard.Specs/ParallelPackageRiskEnricherSpecs.cs
+++ b/Src/PackageGuard.Specs/ParallelPackageRiskEnricherSpecs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -72,7 +73,8 @@ public class ParallelPackageRiskEnricherSpecs
     [TestCategory("Integration")]
     public async Task GitHub_enricher_should_populate_repository_data_for_a_well_known_package()
     {
-        var enricher = new GitHubRepositoryRiskEnricher(NullLogger.Instance, gitHubApiKey: null);
+        var enricher = new GitHubRepositoryRiskEnricher(NullLogger.Instance,
+            gitHubApiKey: Environment.GetEnvironmentVariable("GITHUB_API_KEY"));
         var package = new PackageInfo
         {
             Name = "Newtonsoft.Json",
@@ -128,7 +130,8 @@ public class ParallelPackageRiskEnricherSpecs
     [TestCategory("Integration")]
     public async Task Full_enrichment_pipeline_should_populate_all_network_risk_signals_for_a_real_package()
     {
-        var enricher = new ParallelPackageRiskEnricher(NullLogger.Instance, gitHubApiKey: null);
+        var enricher = new ParallelPackageRiskEnricher(NullLogger.Instance,
+            gitHubApiKey: Environment.GetEnvironmentVariable("GITHUB_API_KEY"));
         var package = new PackageInfo
         {
             Name = "Newtonsoft.Json",


### PR DESCRIPTION
## Summary

- **`OsvRiskEnricher`** had no error handling in `QueryAsync` — any network failure (e.g. SSL error) propagated unhandled all the way to the build runner, producing a generic one-liner with no diagnostic context. Added a `try/catch` that logs the full exception at `Warning` level and returns gracefully.
- **`GitHubRepositoryRiskEnricher`** and **`LicenseUrlRiskEnricher`** both caught exceptions but only logged `ex.Message`, silently dropping inner exception details. Switched to `logger.LogDebug(ex, ...)` so the full exception chain (including the real SSL/socket cause) is included in the log output.
- Injected `ILogger` into `OsvRiskEnricher` (previously it had none) and threaded it through `ParallelPackageRiskEnricher`.

## Test plan

- [ ] Reproduce a network failure (e.g. block `api.osv.dev` in the hosts file) and confirm a `Warning`-level log with the full inner exception is emitted instead of a crash
- [ ] Confirm the build still passes: `dotnet build`
- [ ] Confirm no new analyzer warnings: `dotnet build -warnaserror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)