### PR TITLE
Promote network error logging to Warning across all HTTP enrichers

### DIFF
--- a/Src/PackageGuard.Core/GitHubRepositoryRiskEnricher.cs
+++ b/Src/PackageGuard.Core/GitHubRepositoryRiskEnricher.cs
@@ -269,6 +269,11 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
                 LastReleaseAt = releaseData.LastReleaseAt
             };
         }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+        {
+            logger.LogWarning(ex, "Failed to fetch GitHub repository risk metadata from {RepositoryApiRoot}", repositoryApiRoot);
+            return null;
+        }
         catch (Exception ex)
         {
             logger.LogDebug(ex, "Failed to fetch GitHub repository risk metadata from {RepositoryApiRoot}", repositoryApiRoot);

--- a/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
+++ b/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
@@ -40,7 +40,7 @@ internal sealed class LicenseUrlRiskEnricher(ILogger logger) : IEnrichPackageRis
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "Failed to validate license URL {LicenseUrl} for {Name} {Version}", package.LicenseUrl, package.Name, package.Version);
+            logger.LogWarning(ex, "Failed to validate license URL {LicenseUrl} for {Name} {Version}", package.LicenseUrl, package.Name, package.Version);
             package.HasValidLicenseUrl = false;
             package.HasValidatedLicenseUrl = true;
         }

--- a/Src/PackageGuard.Core/Npm/NpmRegistryMetadataFetcher.cs
+++ b/Src/PackageGuard.Core/Npm/NpmRegistryMetadataFetcher.cs
@@ -313,8 +313,8 @@ public class NpmRegistryMetadataFetcher(ILogger logger)
         }
         catch (Exception ex)
         {
-            logger.LogDebug("Failed to fetch download count for {Name} {Version}: {Error}",
-                package.Name, package.Version, ex.Message);
+            logger.LogWarning(ex, "Failed to fetch download count for {Name} {Version}",
+                package.Name, package.Version);
         }
     }
 


### PR DESCRIPTION
## What changed

All HTTP-based enrichers and fetchers now surface network failures at `Warning` level instead of swallowing them at `Debug`.

**`GitHubRepositoryRiskEnricher`** — HTTP 403 (rate limit exceeded) responses from the GitHub API were previously swallowed into a catch-all `Exception` handler and logged at `Debug` level. A dedicated `catch (HttpRequestException ex) when (ex.StatusCode == Forbidden)` clause now logs these at `Warning`. Other exceptions (e.g. 404, connectivity errors) remain at `Debug` to avoid noise.

**`LicenseUrlRiskEnricher`** — network failures while validating a package's license URL were logged at `Debug`; promoted to `Warning`.

**`NpmRegistryMetadataFetcher`** — failures fetching the npm download count were logged at `Debug` with a string-interpolated message; promoted to `Warning` and aligned to pass the exception object (consistent with structured logging elsewhere).

The following were already correct and required no changes: `OsvRiskEnricher`, `NpmRegistryMetadataFetcher.FetchMetadataAsync`, `UrlLicenseFetcher`, and `GitHubLicenseFetcher` (covered by `LicenseFetcher.TryFetchLicenseAsync`).

## Why

Network errors that prevent meaningful package analysis are actionable — they tell the user something is wrong (rate limit hit, unreachable endpoint, bad URL). Surfacing them as `Warning` makes them visible in normal operation without requiring debug logging to be enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)