### PR TITLE
Add -v/--verbose flag for debug-level logging

### DIFF
--- a/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Src/PackageGuard.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -266,7 +266,7 @@ namespace PackageGuard.Core.CSharp.FetchingStrategies
 {
     public class GitHubLicenseFetcher : PackageGuard.Core.CSharp.FetchingStrategies.IFetchLicense
     {
-        public GitHubLicenseFetcher(string? gitHubApiKey) { }
+        public GitHubLicenseFetcher(Microsoft.Extensions.Logging.ILogger logger, string? gitHubApiKey) { }
         public System.Threading.Tasks.Task FetchLicenseAsync(PackageGuard.Core.PackageInfo package) { }
     }
     public interface IFetchLicense

--- a/Src/PackageGuard.Core/CSharp/FetchingStrategies/GitHubLicenseFetcher.cs
+++ b/Src/PackageGuard.Core/CSharp/FetchingStrategies/GitHubLicenseFetcher.cs
@@ -1,13 +1,14 @@
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 
 namespace PackageGuard.Core.CSharp.FetchingStrategies;
 
 /// <summary>
 /// Fetches licenses using GitHub metadata and an optional GitHub API key to prevent rate limiting.
 /// </summary>
-public class GitHubLicenseFetcher(string? gitHubApiKey) : IFetchLicense
+public class GitHubLicenseFetcher(ILogger logger, string? gitHubApiKey) : IFetchLicense
 {
     private static readonly HttpClient HttpClient = new();
 
@@ -24,6 +25,7 @@ public class GitHubLicenseFetcher(string? gitHubApiKey) : IFetchLicense
 
             if (url is not null)
             {
+                logger.LogDebug("Fetching GitHub license from {Url}", url);
                 using var request = new HttpRequestMessage(HttpMethod.Get, url);
                 if (gitHubApiKey is not null)
                 {

--- a/Src/PackageGuard.Core/CSharp/FetchingStrategies/UrlLicenseFetcher.cs
+++ b/Src/PackageGuard.Core/CSharp/FetchingStrategies/UrlLicenseFetcher.cs
@@ -16,6 +16,7 @@ public class UrlLicenseFetcher(ILogger logger) : IFetchLicense
         {
             try
             {
+                logger.LogDebug("Fetching license text from {Url}", package.LicenseUrl);
                 string licenseText = await HttpClient.GetStringAsync(package.LicenseUrl);
 
                 if (licenseText.Contains("MIT license", StringComparison.OrdinalIgnoreCase))

--- a/Src/PackageGuard.Core/CSharp/NuGetPackageAnalyzer.cs
+++ b/Src/PackageGuard.Core/CSharp/NuGetPackageAnalyzer.cs
@@ -176,6 +176,7 @@ public class NuGetPackageAnalyzer(ILogger logger, LicenseFetcher licenseFetcher)
 
         foreach (SourceRepository nuGetSource in projectNuGetSources)
         {
+            logger.LogDebug("Querying {SourceUrl} for {Name} {Version}", nuGetSource.PackageSource.Source, packageName, packageVersion);
             var metadataResource = await nuGetSource.GetResourceAsync<PackageMetadataResource>();
 
             IPackageSearchMetadata[] packageMetadata = (await metadataResource.GetMetadataAsync(

--- a/Src/PackageGuard.Core/GitHubRepositoryRiskEnricher.cs
+++ b/Src/PackageGuard.Core/GitHubRepositoryRiskEnricher.cs
@@ -284,6 +284,7 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     /// <summary>Sends an authenticated GET request and parses the JSON response.</summary>
     private async Task<JsonDocument> GetJsonAsync(string url)
     {
+        logger.LogDebug("GET {Url}", url);
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
 
@@ -1086,8 +1087,9 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using HttpResponseMessage response = await HttpClient.GetAsync(
-                $"https://api.securityscorecards.dev/projects/github.com/{owner}/{repo}");
+            string scorecardUrl = $"https://api.securityscorecards.dev/projects/github.com/{owner}/{repo}";
+            logger.LogDebug("GET {Url}", scorecardUrl);
+            using HttpResponseMessage response = await HttpClient.GetAsync(scorecardUrl);
             response.EnsureSuccessStatusCode();
 
             using JsonDocument scorecardDoc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());

--- a/Src/PackageGuard.Core/GitHubRepositoryRiskEnricher.cs
+++ b/Src/PackageGuard.Core/GitHubRepositoryRiskEnricher.cs
@@ -269,6 +269,11 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
                 LastReleaseAt = releaseData.LastReleaseAt
             };
         }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+        {
+            logger.LogWarning(ex, "Failed to fetch GitHub repository risk metadata from {RepositoryApiRoot}", repositoryApiRoot);
+            return null;
+        }
         catch (Exception ex)
         {
             logger.LogDebug(ex, "Failed to fetch GitHub repository risk metadata from {RepositoryApiRoot}", repositoryApiRoot);

--- a/Src/PackageGuard.Core/LicenseFetcher.cs
+++ b/Src/PackageGuard.Core/LicenseFetcher.cs
@@ -16,7 +16,7 @@ public sealed class LicenseFetcher(ILogger logger, string? gitHubApiKey = null)
     private readonly IReadOnlyList<IFetchLicense> fetchers =
         [
             new CorrectMisbehavingPackagesFetcher(),
-            new GitHubLicenseFetcher(gitHubApiKey),
+            new GitHubLicenseFetcher(logger, gitHubApiKey),
             new UrlLicenseFetcher(logger)
         ];
 

--- a/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
+++ b/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
@@ -32,6 +32,7 @@ internal sealed class LicenseUrlRiskEnricher(ILogger logger) : IEnrichPackageRis
 
         try
         {
+            logger.LogDebug("Validating license URL {Url}", package.LicenseUrl);
             using HttpResponseMessage response = await HttpClient.GetAsync(package.LicenseUrl,
                 HttpCompletionOption.ResponseHeadersRead);
 

--- a/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
+++ b/Src/PackageGuard.Core/LicenseUrlRiskEnricher.cs
@@ -40,7 +40,7 @@ internal sealed class LicenseUrlRiskEnricher(ILogger logger) : IEnrichPackageRis
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "Failed to validate license URL {LicenseUrl} for {Name} {Version}", package.LicenseUrl, package.Name, package.Version);
+            logger.LogWarning(ex, "Failed to validate license URL {LicenseUrl} for {Name} {Version}", package.LicenseUrl, package.Name, package.Version);
             package.HasValidLicenseUrl = false;
             package.HasValidatedLicenseUrl = true;
         }

--- a/Src/PackageGuard.Core/Npm/NpmRegistryMetadataFetcher.cs
+++ b/Src/PackageGuard.Core/Npm/NpmRegistryMetadataFetcher.cs
@@ -313,8 +313,8 @@ public class NpmRegistryMetadataFetcher(ILogger logger)
         }
         catch (Exception ex)
         {
-            logger.LogDebug("Failed to fetch download count for {Name} {Version}: {Error}",
-                package.Name, package.Version, ex.Message);
+            logger.LogWarning(ex, "Failed to fetch download count for {Name} {Version}",
+                package.Name, package.Version);
         }
     }
 

--- a/Src/PackageGuard.Core/Npm/NpmRegistryMetadataFetcher.cs
+++ b/Src/PackageGuard.Core/Npm/NpmRegistryMetadataFetcher.cs
@@ -302,6 +302,7 @@ public class NpmRegistryMetadataFetcher(ILogger logger)
         {
             string packageName = Uri.EscapeDataString(package.Name);
             string downloadsUrl = $"https://api.npmjs.org/downloads/point/last-month/{packageName}";
+            logger.LogDebug("Fetching download count from {Url}", downloadsUrl);
             string jsonContent = await HttpClient.GetStringAsync(downloadsUrl);
             using JsonDocument doc = JsonDocument.Parse(jsonContent);
 

--- a/Src/PackageGuard.Core/OsvRiskEnricher.cs
+++ b/Src/PackageGuard.Core/OsvRiskEnricher.cs
@@ -85,6 +85,7 @@ internal sealed class OsvRiskEnricher(ILogger logger) : IEnrichPackageRisk
 
         do
         {
+            logger.LogDebug("Querying OSV API for {Name} {Version}", package.Name, package.Version);
             using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.osv.dev/v1/query");
             request.Content = new StringContent(CreateRequestBody(package, ecosystem, pageToken), Encoding.UTF8, "application/json");
 

--- a/Src/PackageGuard/AnalyzeCommand.cs
+++ b/Src/PackageGuard/AnalyzeCommand.cs
@@ -32,6 +32,11 @@ internal sealed class AnalyzeCommand(ILogger logger) : AsyncCommand<AnalyzeComma
         var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown";
         logger.LogHeader($"PackageGuard v{version}");
 
+        if (settings.Verbose)
+        {
+            logger.LogInformation("Verbose logging enabled — debug-level output is active");
+        }
+
         var licenseFetcher = new LicenseFetcher(logger, settings.GitHubApiKey);
         var riskEvaluator = new RiskEvaluator(logger);
         var analyzer = new ProjectAnalyzer(licenseFetcher, riskEvaluator)

--- a/Src/PackageGuard/AnalyzeCommandSettings.cs
+++ b/Src/PackageGuard/AnalyzeCommandSettings.cs
@@ -101,7 +101,7 @@ internal class AnalyzeCommandSettings : CommandSettings
     [CommandOption("--report-risk|--reportrisk")]
     public bool ReportRisk { get; set; }
 
-    [Description("Enable verbose (debug-level) logging output.")]
+    [Description("Enable verbose (debug-level) logging output. Combine with --report-risk to see individual HTTP calls to GitHub, OSV, and npm registries.")]
     [CommandOption("-v|--verbose")]
     [DefaultValue(false)]
     public bool Verbose { get; set; }

--- a/Src/PackageGuard/AnalyzeCommandSettings.cs
+++ b/Src/PackageGuard/AnalyzeCommandSettings.cs
@@ -101,6 +101,11 @@ internal class AnalyzeCommandSettings : CommandSettings
     [CommandOption("--report-risk|--reportrisk")]
     public bool ReportRisk { get; set; }
 
+    [Description("Enable verbose (debug-level) logging output.")]
+    [CommandOption("-v|--verbose")]
+    [DefaultValue(false)]
+    public bool Verbose { get; set; }
+
     /// <summary>
     /// Returns the report risk output path when overridden via the
     /// <see cref="ReportRiskPathOverrideEnvironmentVariable"/> environment variable, or <c>null</c> if not set.

--- a/Src/PackageGuard/Program.cs
+++ b/Src/PackageGuard/Program.cs
@@ -9,10 +9,14 @@ using Spectre.Console.Cli.Extensions.DependencyInjection;
 using Vertical.SpectreLogger;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
+bool verbose = args.Contains("--verbose", StringComparer.OrdinalIgnoreCase)
+            || args.Contains("-v", StringComparer.OrdinalIgnoreCase);
+LogLevel minLogLevel = verbose ? LogLevel.Debug : LogLevel.Information;
+
 var services = new ServiceCollection();
 
 services.AddLogging(configure => configure
-    .SetMinimumLevel(LogLevel.Debug)
+    .SetMinimumLevel(minLogLevel)
     .AddSerilog()
     .AddSpectreConsole(b => b
         .ConfigureProfile(LogLevel.Trace, p => p.OutputTemplate = "[grey35]{Message}{NewLine}{Exception}[/]")
@@ -20,7 +24,7 @@ services.AddLogging(configure => configure
         .ConfigureProfile(LogLevel.Information, p => p.OutputTemplate = "[grey85]{Message}{NewLine}{Exception}[/]")
         .ConfigureProfile(LogLevel.Warning, p => p.OutputTemplate = "[gold1]{Message}{NewLine}{Exception}[/]")
         .ConfigureProfile(LogLevel.Error, p => p.OutputTemplate = "[white on red1]{Message}{NewLine}{Exception}[/]")
-        .SetMinimumLevel(LogLevel.Debug)));
+        .SetMinimumLevel(minLogLevel)));
 
 services.AddSingleton<ILogger>(sp => sp
     .GetRequiredService<ILoggerFactory>()


### PR DESCRIPTION
## What changed

Adds a `-v`/`--verbose` flag to `AnalyzeCommandSettings`. When set, the minimum log level is `Debug`; without it, the default is `Information`.

The logging infrastructure in `Program.cs` is configured before Spectre.Console parses arguments, so `--verbose` is detected with a pre-scan of `args` — consistent with the existing `ReportRiskArgumentNormalizer` pattern already in that file.

## Why

The log level was previously hardcoded to `Debug`, meaning diagnostic output was always shown. This is noisy during normal operation. With this change:

- Default output is clean: `Information`, `Warning`, and `Error` only.
- Pass `-v` or `--verbose` to see `Debug`-level messages (HTTP calls, cache hits, per-package detail) when diagnosing issues.

This makes the `Warning`-level network error logging added in the parent PR immediately visible to users without any extra flags, while keeping verbose diagnostics opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)