### PR TITLE
Stop Dependabot from bumping Verify.DiffPlex past 3.1.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Verify.DiffPlex versions beyond 3.1.2 require a newer Verify core package
+      # than the one Verify.Xunit 31.12.5 was built against, which causes a
+      # MethodAccessException in the API approval tests at runtime (see PR #204
+      # and PR #228). Remove this once Verify.Xunit ships a release compatible
+      # with a newer Verify.DiffPlex, and bump both together.
+      - dependency-name: "Verify.DiffPlex"
+        versions: [">3.1.2"]


### PR DESCRIPTION
## Why

`Verify.DiffPlex` versions above 3.1.2 depend on a newer `Verify` core package than the one `Verify.Xunit` 31.12.5 was built against. When both land in the same test project, `Guards.AgainstBadSourceFile` is resolved against a different-accessibility copy of the assembly, causing a `System.MethodAccessException` at runtime and failing `PackageGuard.ApiVerificationTests.ApiApproval.ApproveApi`.

This has already broken two Dependabot dependency-group PRs:
- PR #204, fixed by pinning `Verify.DiffPlex` back to 3.1.2 (commit 0bf1c1a)
- PR #228, fixed the same way

## What

Add an `ignore` rule to `.github/dependabot.yml` so Dependabot stops proposing `Verify.DiffPlex` versions above 3.1.2. The rule should be removed once `Verify.Xunit` ships a release compatible with a newer `Verify.DiffPlex`, at which point both should be bumped together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)