### PR TITLE
Migrate remaining raw Path/Directory calls to Pathy's ChainablePath

### DIFF
--- a/Src/PackageGuard.Core/CSharp/CSharpProjectScanner.cs
+++ b/Src/PackageGuard.Core/CSharp/CSharpProjectScanner.cs
@@ -89,7 +89,7 @@ public class CSharpProjectScanner(ILogger logger)
 
             var solutionPath = solution.Value;
             // Parse .sln file using Microsoft.Build
-            var solutionFile = SolutionFile.Parse(Path.GetFullPath(solutionPath, Environment.CurrentDirectory));
+            var solutionFile = SolutionFile.Parse(solutionPath.ToAbsolute());
             foreach (ProjectInSolution? project in solutionFile.ProjectsInOrder)
             {
                 if (project.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat)

--- a/Src/PackageGuard.Core/CSharp/NuGetPackageAnalyzer.cs
+++ b/Src/PackageGuard.Core/CSharp/NuGetPackageAnalyzer.cs
@@ -8,6 +8,7 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using PackageGuard.Core.Common;
 using PackageGuard.Core.Package;
+using Pathy;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace PackageGuard.Core.CSharp;
@@ -281,8 +282,8 @@ public class NuGetPackageAnalyzer(ILogger logger, LicenseFetcher licenseFetcher)
 
         foreach (string version in EnumerateVersionCandidates(packageVersion))
         {
-            string nuspecPath = Path.Combine(globalPackagesFolder, packageId, version, $"{packageId}.nuspec");
-            if (!File.Exists(nuspecPath))
+            ChainablePath nuspecPath = ChainablePath.From(globalPackagesFolder) / packageId / version / $"{packageId}.nuspec";
+            if (!nuspecPath.IsFile)
             {
                 continue;
             }

--- a/Src/PackageGuard.Core/Risk/Enrichment/NuGetPackageSigningRiskEnricher.cs
+++ b/Src/PackageGuard.Core/Risk/Enrichment/NuGetPackageSigningRiskEnricher.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using NuGet.Configuration;
 using NuGet.Versioning;
 using PackageGuard.Core.Package;
+using Pathy;
 
 namespace PackageGuard.Core.Risk.Enrichment;
 
@@ -87,8 +88,8 @@ internal sealed class NuGetPackageSigningRiskEnricher(ILogger logger, string? gl
         string packageId = package.Name.ToLowerInvariant();
         foreach (string version in EnumerateVersionCandidates(package.Version))
         {
-            string path = Path.Combine(globalPackagesFolder, packageId, version, $"{packageId}.{version}.nupkg");
-            if (File.Exists(path))
+            ChainablePath path = ChainablePath.From(globalPackagesFolder) / packageId / version / $"{packageId}.{version}.nupkg";
+            if (path.IsFile)
             {
                 return path;
             }

--- a/Src/PackageGuard.Core/Sbom/SbomModelBuilder.cs
+++ b/Src/PackageGuard.Core/Sbom/SbomModelBuilder.cs
@@ -1,4 +1,5 @@
 using PackageGuard.Core.Package;
+using Pathy;
 
 namespace PackageGuard.Core.Sbom;
 
@@ -103,12 +104,14 @@ internal static class SbomModelBuilder
     /// </summary>
     private static string ResolveRootName(string projectPath)
     {
-        if (File.Exists(projectPath))
+        if (string.IsNullOrEmpty(projectPath))
         {
             return Path.GetFileNameWithoutExtension(projectPath);
         }
 
-        if (!Directory.Exists(projectPath))
+        ChainablePath path = ChainablePath.From(projectPath);
+
+        if (path.IsFile || !path.IsDirectory)
         {
             return Path.GetFileNameWithoutExtension(projectPath);
         }
@@ -120,6 +123,6 @@ internal static class SbomModelBuilder
 
         return candidate is not null
             ? Path.GetFileNameWithoutExtension(candidate)
-            : new DirectoryInfo(projectPath).Name;
+            : path.Name;
     }
 }

--- a/Src/PackageGuard.Core/Sbom/SbomWriter.cs
+++ b/Src/PackageGuard.Core/Sbom/SbomWriter.cs
@@ -1,4 +1,5 @@
 using PackageGuard.Core.Package;
+using Pathy;
 
 namespace PackageGuard.Core.Sbom;
 
@@ -21,10 +22,10 @@ internal static class SbomWriter
             ? SpdxSbomWriter.Build(model)
             : CycloneDxSbomWriter.Build(model);
 
-        string? outputDirectory = Path.GetDirectoryName(Path.GetFullPath(outputPath));
-        if (!string.IsNullOrEmpty(outputDirectory))
+        ChainablePath outputDirectory = ChainablePath.From(outputPath).ToAbsolute().Directory;
+        if (outputDirectory != ChainablePath.Empty)
         {
-            Directory.CreateDirectory(outputDirectory);
+            outputDirectory.CreateDirectoryRecursively();
         }
 
         File.WriteAllText(outputPath, json);

--- a/Src/PackageGuard/RiskHtmlReportWriter.cs
+++ b/Src/PackageGuard/RiskHtmlReportWriter.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using PackageGuard.Core;
 using PackageGuard.Core.Package;
+using Pathy;
 
 namespace PackageGuard;
 
@@ -57,9 +58,9 @@ internal static class RiskHtmlReportWriter
             return ResolveConfiguredReportPaths(projectPath, reportLocation);
         }
 
-        string reportDirectory = Path.Combine(Path.GetTempPath(), "PackageGuard", "reports");
+        ChainablePath reportDirectory = ChainablePath.Temp / "PackageGuard" / "reports";
 
-        Directory.CreateDirectory(reportDirectory);
+        reportDirectory.CreateDirectoryRecursively();
 
         return CreateGeneratedReportPaths(projectPath, reportDirectory);
     }
@@ -72,30 +73,32 @@ internal static class RiskHtmlReportWriter
     {
         if (LooksLikeDirectoryPath(reportLocation))
         {
-            Directory.CreateDirectory(reportLocation);
-            return CreateGeneratedReportPaths(projectPath, reportLocation);
+            ChainablePath directory = ChainablePath.From(reportLocation);
+            directory.CreateDirectoryRecursively();
+            return CreateGeneratedReportPaths(projectPath, directory);
         }
 
-        string fullPath = Path.GetFullPath(reportLocation);
-        string? parentDirectory = Path.GetDirectoryName(fullPath);
-        if (!string.IsNullOrWhiteSpace(parentDirectory))
+        ChainablePath fullPath = ChainablePath.From(reportLocation).ToAbsolute();
+        ChainablePath parentDirectory = fullPath.Directory;
+        if (parentDirectory != ChainablePath.Empty)
         {
-            Directory.CreateDirectory(parentDirectory);
+            parentDirectory.CreateDirectoryRecursively();
         }
 
-        string extension = Path.GetExtension(fullPath);
+        string extension = fullPath.Extension;
         string fileStem = string.IsNullOrWhiteSpace(extension)
             ? fullPath
-            : Path.Combine(Path.GetDirectoryName(fullPath) ?? string.Empty, Path.GetFileNameWithoutExtension(fullPath));
+            : parentDirectory / Path.GetFileNameWithoutExtension(fullPath.Name);
 
+        string fullPathAsString = fullPath;
         string htmlPath = extension.Equals(".sarif", StringComparison.OrdinalIgnoreCase)
             ? $"{fileStem}.html"
             : string.IsNullOrWhiteSpace(extension) || extension.Equals(".html", StringComparison.OrdinalIgnoreCase)
                 ? $"{fileStem}.html"
-                : fullPath;
+                : fullPathAsString;
 
         string sarifPath = extension.Equals(".sarif", StringComparison.OrdinalIgnoreCase)
-            ? fullPath
+            ? fullPathAsString
             : $"{fileStem}.sarif";
 
         return new RiskReportPaths(htmlPath, sarifPath);
@@ -107,21 +110,22 @@ internal static class RiskHtmlReportWriter
     /// </summary>
     private static bool LooksLikeDirectoryPath(string reportLocation)
     {
-        if (Directory.Exists(reportLocation))
+        ChainablePath path = ChainablePath.From(reportLocation);
+        if (path.IsDirectory)
         {
             return true;
         }
 
         return reportLocation.EndsWith(Path.DirectorySeparatorChar) ||
                reportLocation.EndsWith(Path.AltDirectorySeparatorChar) ||
-               string.IsNullOrWhiteSpace(Path.GetExtension(reportLocation));
+               string.IsNullOrWhiteSpace(path.Extension);
     }
 
     /// <summary>
     /// Creates timestamped HTML and SARIF report file paths inside <paramref name="reportDirectory"/>,
     /// using a sanitised form of the project name as the file stem.
     /// </summary>
-    private static RiskReportPaths CreateGeneratedReportPaths(string projectPath, string reportDirectory)
+    private static RiskReportPaths CreateGeneratedReportPaths(string projectPath, ChainablePath reportDirectory)
     {
         string projectName = Path.GetFileNameWithoutExtension(projectPath);
         if (string.IsNullOrWhiteSpace(projectName))
@@ -134,8 +138,8 @@ internal static class RiskHtmlReportWriter
 
         string fileNamePrefix = $"{sanitizedProjectName}-risk-report-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}";
         return new RiskReportPaths(
-            Path.Combine(reportDirectory, $"{fileNamePrefix}.html"),
-            Path.Combine(reportDirectory, $"{fileNamePrefix}.sarif"));
+            reportDirectory / $"{fileNamePrefix}.html",
+            reportDirectory / $"{fileNamePrefix}.sarif");
     }
 
     /// <summary>
@@ -175,7 +179,7 @@ internal static class RiskHtmlReportWriter
         builder.AppendLine("<head>");
         builder.AppendLine("  <meta charset=\"utf-8\">");
         builder.AppendLine("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
-        builder.AppendLine($"  <title>{Encode(Path.GetFileName(projectPath))} - PackageGuard Risk Report</title>");
+        builder.AppendLine($"  <title>{Encode(ChainablePath.From(projectPath).Name)} - PackageGuard Risk Report</title>");
         builder.AppendLine("  <style>");
         builder.AppendLine(
             "    body { font-family: Segoe UI, Arial, sans-serif; margin: 0; background: #f8fafc; color: #0f172a; }");
@@ -1123,6 +1127,6 @@ internal static class RiskHtmlReportWriter
             return projectPath;
         }
 
-        return Path.Combine(projectPath, "package.json");
+        return ChainablePath.From(projectPath) / "package.json";
     }
 }

--- a/Src/PackageGuard/RiskSarifReportWriter.cs
+++ b/Src/PackageGuard/RiskSarifReportWriter.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using PackageGuard.Core;
 using PackageGuard.Core.Package;
+using Pathy;
 
 namespace PackageGuard;
 
@@ -159,26 +160,27 @@ internal static class RiskSarifReportWriter
     /// </summary>
     private static string ResolveLocationPath(string projectPath)
     {
-        string rootPath = ResolveRootPath(projectPath);
+        ChainablePath path = ChainablePath.From(projectPath);
+        string rootPath = ResolveRootPath(path);
 
-        if (File.Exists(projectPath))
+        if (path.IsFile)
         {
-            return ToSarifUri(rootPath, projectPath);
+            return ToSarifUri(rootPath, path);
         }
 
-        if (!Directory.Exists(projectPath))
+        if (!path.IsDirectory)
         {
-            return ToSarifUri(rootPath, projectPath);
+            return ToSarifUri(rootPath, path);
         }
 
-        string[] preferredFiles =
+        ChainablePath[] preferredFiles =
         [
-            Path.Combine(projectPath, ".packageguard", "config.json"),
-            Path.Combine(projectPath, "packageguard.config.json")
+            path / ".packageguard" / "config.json",
+            path / "packageguard.config.json"
         ];
 
-        string? preferred = preferredFiles.FirstOrDefault(File.Exists);
-        if (preferred is not null)
+        ChainablePath preferred = preferredFiles.FirstOrDefault(candidate => candidate.IsFile, ChainablePath.Empty);
+        if (preferred != ChainablePath.Empty)
         {
             return ToSarifUri(rootPath, preferred);
         }
@@ -194,17 +196,17 @@ internal static class RiskSarifReportWriter
     /// <summary>
     /// Returns the absolute root directory to use when computing relative SARIF URIs.
     /// </summary>
-    private static string ResolveRootPath(string projectPath)
+    private static string ResolveRootPath(ChainablePath path)
     {
-        if (Directory.Exists(projectPath))
+        if (path.IsDirectory)
         {
-            return Path.GetFullPath(projectPath);
+            return path.ToAbsolute();
         }
 
-        string? directory = Path.GetDirectoryName(projectPath);
-        return string.IsNullOrWhiteSpace(directory)
+        ChainablePath directory = path.Directory;
+        return directory == ChainablePath.Empty
             ? Directory.GetCurrentDirectory()
-            : Path.GetFullPath(directory);
+            : directory.ToAbsolute();
     }
 
     /// <summary>
@@ -231,7 +233,7 @@ internal static class RiskSarifReportWriter
     {
         relativeUri = null;
 
-        string relativePath = Path.GetRelativePath(rootPath, fullPath);
+        string relativePath = ChainablePath.From(fullPath).AsRelativeTo(ChainablePath.From(rootPath));
         if (relativePath.StartsWith("..", StringComparison.Ordinal))
         {
             return false;
@@ -275,7 +277,7 @@ internal static class RiskSarifReportWriter
             return projectPath;
         }
 
-        return Path.Combine(projectPath, "package.json");
+        return ChainablePath.From(projectPath) / "package.json";
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Pathy is already a dependency of `PackageGuard` and `PackageGuard.Core` (v1.8.0) and is already used throughout the project/config-discovery code (`ConfigurationLoader`, `CSharpProjectScanner`, npm lock-file parsers, etc.). This PR finishes that migration by converting the remaining raw `System.IO.Path`/`Directory` call sites in the risk-reporting and SBOM code to `ChainablePath`:

- **`RiskHtmlReportWriter`** / **`RiskSarifReportWriter`** — the biggest win. Replaces chained `Path.Combine`/`Path.GetFullPath`/`Path.GetDirectoryName`/`Path.GetExtension` logic (directory-vs-file sniffing, `.html`/`.sarif` extension swapping, parent-directory creation) with `ChainablePath`'s `/` operator, `.Directory`, `.Extension`, `.IsFile`, `.IsDirectory`, and `.CreateDirectoryRecursively()`. The SARIF relative-URI computation now uses `AsRelativeTo()`.
- **`SbomWriter`** / **`SbomModelBuilder`** — simplifies output-directory creation and root-name resolution.
- **`NuGetPackageAnalyzer`** / **`NuGetPackageSigningRiskEnricher`** — builds the nuspec/nupkg global-cache paths via the `/` operator instead of `Path.Combine`.
- **`CSharpProjectScanner`** — drops the one remaining raw `Path.GetFullPath` call in favor of `ChainablePath.ToAbsolute()`.

## Why

This code predates (or was missed by) the earlier Pathy adoption, so it carries fragile hand-rolled logic for things Pathy already handles (directory vs. file detection, trailing-separator handling, parent-directory creation). Consolidating onto one path abstraction reduces the surface area for `Path.Combine`/`null`-directory-name bugs and matches the convention already used elsewhere in the codebase.


🤖 Generated with [Claude Code](https://claude.com/claude-code)