### PR TITLE
--npm None no longer throws, now disables NPM scanning as intended

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ OPTIONS:
         --risk-cache-max-age-hours 24       Maximum age in hours for cached risk-related package data before
                                             --report-risk refreshes it
         --nuget                  True       Explicitly enable or disable scanning for .csproj, .sln or .slnx files
-        --npm                               Explicitly specify the package manager to use (npm, yarn, pnpm). If not
-                                            specified, it will detect it automatically
+        --npm                               Explicitly specify the package manager to use (npm, yarn, pnpm), or None
+                                            to disable NPM scanning entirely. If not specified, it will detect it
+                                            automatically
         --npm-exe-path                      The path to the npm, yarn or pnpm executable. If not specified, the system
                                             PATH is used
         --report-risk                       Show a colored risk summary in the console and generate detailed HTML/SARIF

--- a/Src/PackageGuard.Core/Npm/NpmProjectAnalysisStrategy.cs
+++ b/Src/PackageGuard.Core/Npm/NpmProjectAnalysisStrategy.cs
@@ -17,6 +17,13 @@ public class NpmProjectAnalysisStrategy(GetPolicyByProject policyByProject, ILog
         // Based on the settings, files on disk or the environment, determine which package manager to use
         DetectPackageManager(projectOrSolutionPath, settings);
 
+        if (settings.NpmPackageManager == NpmPackageManager.None)
+        {
+            logger.LogInformation("NPM scanning is explicitly disabled, so skipping NPM analysis");
+
+            return violations.ToArray();
+        }
+
         // Find the package.json file, either because the path points to it directly, or it's in the folder
         ChainablePath packageJsonPath = projectOrSolutionPath.ToPath();
         packageJsonPath = packageJsonPath.ResolveFile("package.json");

--- a/Src/PackageGuard.Specs/Npm/ProjectAnalyzerSpecs.cs
+++ b/Src/PackageGuard.Specs/Npm/ProjectAnalyzerSpecs.cs
@@ -316,6 +316,33 @@ public class ProjectAnalyzerSpecs
     }
 
     [TestMethod]
+    public async Task Can_disable_npm_scanning_entirely()
+    {
+        // Arrange
+        var project = ChainablePath.Current / "TestCases" / "NpmApp";
+
+        var analyzer = new ProjectAnalyzer(licenseFetcher)
+        {
+            Logger = ConsoleTestLogger.Create("Test")
+        };
+
+        // Act
+        var violations = await analyzer.ExecuteAnalysis(project, new AnalyzerSettings
+        {
+            NpmPackageManager = NpmPackageManager.None,
+        }, _ => new ProjectPolicy
+        {
+            AllowList = new AllowList
+            {
+                Licenses = ["not-mit"]
+            },
+        });
+
+        // Assert
+        violations.Should().BeEmpty();
+    }
+
+    [TestMethod]
     public async Task Can_prevent_fetching_metadata_from_a_private_npm_feed()
     {
         // Arrange

--- a/Src/PackageGuard/AnalyzeCommandSettings.cs
+++ b/Src/PackageGuard/AnalyzeCommandSettings.cs
@@ -89,7 +89,7 @@ public class AnalyzeCommandSettings : CommandSettings
     public bool ScanNuGet { get; set; }
 
     [Description(
-        "Explicitly specify the package manager to use (npm, yarn, pnpm). If not specified, it will detect it automatically.")]
+        "Explicitly specify the package manager to use (npm, yarn, pnpm), or None to disable NPM scanning entirely. If not specified, it will detect it automatically.")]
     [CommandOption("--npm")]
     public NpmPackageManager? NpmPackageManager { get; set; }
 


### PR DESCRIPTION
Fixes #237

## Problem

Passing `--npm None` was intended to disable NPM/Node scanning entirely (mirroring how `--nuget false` disables NuGet scanning), but instead it crashed with a `KeyNotFoundException`.

`NpmProjectAnalysisStrategy.ExecuteAnalysis` unconditionally tried to resolve a lock file once a `package.json` was found, even when `NpmPackageManager.None` was explicitly configured. `LockFileLoader.GetPackageLockFile` indexes a dictionary (`lockFileByManager`) that only has entries for `Npm`, `Yarn`, and `Pnpm`, so looking it up with `None` threw.

## Fix

Added an early return in `NpmProjectAnalysisStrategy.ExecuteAnalysis`: when `settings.NpmPackageManager == NpmPackageManager.None`, NPM analysis is skipped entirely (no lock file resolution, no restore, no violations), with an informational log message.

## Testing

Added `Can_disable_npm_scanning_entirely` in `Src/PackageGuard.Specs/Npm/ProjectAnalyzerSpecs.cs`, asserting that analyzing a project with a `package.json` and `NpmPackageManager = NpmPackageManager.None` produces no violations and no exception.

Ran the full npm test suite: `dotnet test Src/PackageGuard.Specs/PackageGuard.Specs.csproj --filter "FullyQualifiedName~ProjectAnalyzerSpecs"` — all 41 tests pass (net9.0 and net10.0).