### PR TITLE
Share one resilient GitHub client across the whole run

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,13 +471,15 @@ If PackageGuard finds new packages in your project or solution that did not exis
 
 ### Github rate limiting issues
 
-If you're running into errors from GitHub like 
-
-  `Response status code does not indicate success: 403 (rate limit exceeded).`
-
-it means PackageGuard has ran into the [rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28) of `api.github.com` while trying to fetch license information from certain repositories. You can solve that by either waiting an hour or creating a GitHub Personal Access Token with the `public_repo` scope. You can find more information about those tokens [here](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps).
+PackageGuard reads license and risk information from `api.github.com`, which applies [rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28) per caller. Unauthenticated callers get 60 requests per hour, which is not enough for anything but the smallest project. Create a GitHub Personal Access Token with the `public_repo` scope to raise that to 5000 requests per hour. You can find more information about those tokens [here](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps).
 
 After having generated such a token, pass it to PackageGuard through its `github-api-key` option or set-up an environment variable named `GITHUB_API_KEY`.
+
+If the limit does run out, PackageGuard reports a warning like
+
+  `The GitHub API rate limit is exhausted and resets in 42 minutes.`
+
+and finishes the analysis without the GitHub-based signals, instead of failing. Run it again after the reset to fill in what was left out. Combine this with `--use-caching` so that the work already done is not repeated: alongside the package cache, PackageGuard stores the GitHub responses it received under `.packageguard\github-responses.bin` and revalidates them with conditional requests, which GitHub does not charge against the rate limit of an authenticated caller.
 
 ## Roadmap
 

--- a/Src/PackageGuard.Core/CSharp/FetchingStrategies/GitHubLicenseFetcher.cs
+++ b/Src/PackageGuard.Core/CSharp/FetchingStrategies/GitHubLicenseFetcher.cs
@@ -1,7 +1,7 @@
-using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using PackageGuard.Core.GitHub;
 using PackageGuard.Core.Package;
 
 namespace PackageGuard.Core.CSharp.FetchingStrategies;
@@ -9,52 +9,83 @@ namespace PackageGuard.Core.CSharp.FetchingStrategies;
 /// <summary>
 /// Fetches licenses using GitHub metadata and an optional GitHub API key to prevent rate limiting.
 /// </summary>
-public class GitHubLicenseFetcher(ILogger logger, string? gitHubApiKey) : IFetchLicense
+public class GitHubLicenseFetcher : IFetchLicense
 {
-    private static readonly HttpClient HttpClient = new();
+    private readonly ILogger logger;
+    private readonly GitHubApiClient apiClient;
 
-    static GitHubLicenseFetcher()
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitHubLicenseFetcher"/> class.
+    /// </summary>
+    /// <param name="logger">The logger to report fetch problems to.</param>
+    /// <param name="gitHubApiKey">The GitHub personal access token to authenticate with, if any.</param>
+    public GitHubLicenseFetcher(ILogger logger, string? gitHubApiKey)
+        : this(logger, GitHubApi.GetOrCreateClient(logger, gitHubApiKey))
     {
-        HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PackageGuard", "v1"));
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitHubLicenseFetcher"/> class that shares the given client.
+    /// </summary>
+    /// <param name="logger">The logger to report fetch problems to.</param>
+    /// <param name="apiClient">The client to send GitHub API requests through.</param>
+    internal GitHubLicenseFetcher(ILogger logger, GitHubApiClient apiClient)
+    {
+        this.logger = logger;
+        this.apiClient = apiClient;
+    }
+
+    /// <summary>
+    /// Resolves the SPDX identifier of the package's license from the license endpoint of its GitHub repository.
+    /// </summary>
+    /// <param name="package">The package to amend with license information.</param>
     public async Task FetchLicenseAsync(PackageInfo package)
     {
-        if (package.RepositoryUrl is not null)
+        string? url = GetGitHubLicenseUrl(package.RepositoryUrl);
+        if (url is null)
         {
-            string? url = GetGitHubLicenseUrl(package.RepositoryUrl);
+            return;
+        }
 
-            if (url is not null)
-            {
-                logger.LogDebug("Fetching GitHub license from {Url}", url);
-                using var request = new HttpRequestMessage(HttpMethod.Get, url);
-                if (gitHubApiKey is not null)
-                {
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", gitHubApiKey);
-                }
+        logger.LogDebug("Fetching GitHub license from {Url}", url);
+        using JsonDocument? document = await apiClient.GetJsonAsync(url);
+        if (document is null)
+        {
+            return;
+        }
 
-                using HttpResponseMessage response = await HttpClient.SendAsync(request);
-                response.EnsureSuccessStatusCode();
-
-                using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-                package.License = doc.RootElement.GetProperty("license").GetProperty("spdx_id").GetString();
-
-                if (package.License?.Equals("noassertion", StringComparison.OrdinalIgnoreCase) == true)
-                {
-                    package.License = null;
-                }
-
-                if (package.License is not null)
-                {
-                    package.LicenseEvidence = LicenseEvidence.Concluded;
-                }
-            }
+        package.License = ReadSpdxIdentifier(document);
+        if (package.License is not null)
+        {
+            package.LicenseEvidence = LicenseEvidence.Concluded;
         }
     }
 
-    private string? GetGitHubLicenseUrl(string repositoryUrl)
+    /// <summary>
+    /// Reads the SPDX identifier from a GitHub license response, treating GitHub's "no assertion" answer as unknown.
+    /// </summary>
+    private static string? ReadSpdxIdentifier(JsonDocument document)
     {
-        string? url = null;
+        if (!document.RootElement.TryGetProperty("license", out JsonElement license) ||
+            !license.TryGetProperty("spdx_id", out JsonElement spdxId))
+        {
+            return null;
+        }
+
+        string? identifier = spdxId.GetString();
+        return identifier?.Equals("noassertion", StringComparison.OrdinalIgnoreCase) == true ? null : identifier;
+    }
+
+    /// <summary>
+    /// Builds the GitHub license endpoint URL for a repository URL, or returns <see langword="null"/> when the URL
+    /// does not point at GitHub.
+    /// </summary>
+    private static string? GetGitHubLicenseUrl(string? repositoryUrl)
+    {
+        if (repositoryUrl is null)
+        {
+            return null;
+        }
 
         const string validCharacters = "[a-zA-Z0-9._-]";
 
@@ -67,14 +98,11 @@ public class GitHubLicenseFetcher(ILogger logger, string? gitHubApiKey) : IFetch
                 $@"github.com\/(?<owner>{validCharacters}+?)\/(?<repo>{validCharacters}+)");
         }
 
-        if (match.Length > 0)
+        if (match.Length == 0)
         {
-            string owner = match.Groups["owner"].Value;
-            string repo = match.Groups["repo"].Value;
-
-            url = $"https://api.github.com/repos/{owner}/{repo}/license";
+            return null;
         }
 
-        return url;
+        return $"https://api.github.com/repos/{match.Groups["owner"].Value}/{match.Groups["repo"].Value}/license";
     }
 }

--- a/Src/PackageGuard.Core/GitHub/GitHubApi.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubApi.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Logging;
+using Pathy;
+
+namespace PackageGuard.Core.GitHub;
+
+/// <summary>
+/// Hands out the <see cref="GitHubApiClient"/> shared by every component that talks to GitHub during a run.
+/// </summary>
+/// <remarks>
+/// Licenses are fetched while projects are being scanned and risk signals are collected afterwards, so the two
+/// phases only stay within a single rate limit budget if they use the same client. Clients are cached per token
+/// because that is what identifies a budget.
+/// </remarks>
+internal static class GitHubApi
+{
+    /// <summary>
+    /// The clients handed out so far, keyed by the token they authenticate with.
+    /// </summary>
+    private static readonly Dictionary<string, GitHubApiClient> ClientsByApiKey = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The conditional-request cache shared by all clients.
+    /// </summary>
+    private static GitHubResponseCache? responseCache;
+
+    /// <summary>
+    /// Guards the shared client and cache instances.
+    /// </summary>
+    private static readonly Lock SharedLock = new();
+
+    /// <summary>
+    /// Returns the client for <paramref name="apiKey"/>, creating it on first use.
+    /// </summary>
+    /// <param name="logger">The logger the client reports throttling to.</param>
+    /// <param name="apiKey">The GitHub personal access token to authenticate with, if any.</param>
+    public static GitHubApiClient GetOrCreateClient(ILogger logger, string? apiKey)
+    {
+        lock (SharedLock)
+        {
+            string cacheKey = apiKey ?? string.Empty;
+            if (!ClientsByApiKey.TryGetValue(cacheKey, out GitHubApiClient? client))
+            {
+                responseCache ??= new GitHubResponseCache(logger);
+                client = new GitHubApiClient(logger, apiKey, responseCache);
+                ClientsByApiKey[cacheKey] = client;
+            }
+
+            return client;
+        }
+    }
+
+    /// <summary>
+    /// Loads previously cached GitHub responses that sit next to the package cache at <paramref name="cacheFilePath"/>.
+    /// </summary>
+    /// <param name="logger">The logger to report cache problems to.</param>
+    /// <param name="cacheFilePath">The path of the package cache file the response cache sits next to.</param>
+    public static async Task LoadResponseCacheAsync(ILogger logger, string cacheFilePath)
+    {
+        GitHubResponseCache cache = GetOrCreateResponseCache(logger);
+        await cache.LoadAsync(GetResponseCacheFilePath(cacheFilePath));
+    }
+
+    /// <summary>
+    /// Persists the GitHub responses seen during this run next to the package cache at <paramref name="cacheFilePath"/>.
+    /// </summary>
+    /// <param name="logger">The logger to report cache problems to.</param>
+    /// <param name="cacheFilePath">The path of the package cache file the response cache sits next to.</param>
+    public static async Task SaveResponseCacheAsync(ILogger logger, string cacheFilePath)
+    {
+        GitHubResponseCache cache = GetOrCreateResponseCache(logger);
+        await cache.SaveAsync(GetResponseCacheFilePath(cacheFilePath));
+    }
+
+    /// <summary>
+    /// Discards the shared client and cache. Only used by the tests, to keep rate limit state from leaking between them.
+    /// </summary>
+    internal static void Reset()
+    {
+        lock (SharedLock)
+        {
+            foreach (GitHubApiClient client in ClientsByApiKey.Values)
+            {
+                client.Dispose();
+            }
+
+            ClientsByApiKey.Clear();
+            responseCache = null;
+        }
+    }
+
+    /// <summary>
+    /// Returns the shared response cache, creating it on first use.
+    /// </summary>
+    private static GitHubResponseCache GetOrCreateResponseCache(ILogger logger)
+    {
+        lock (SharedLock)
+        {
+            return responseCache ??= new GitHubResponseCache(logger);
+        }
+    }
+
+    /// <summary>
+    /// Derives the response cache file path from the package cache file path.
+    /// </summary>
+    private static string GetResponseCacheFilePath(string cacheFilePath) =>
+        cacheFilePath.ToPath().Directory / "github-responses.bin";
+}

--- a/Src/PackageGuard.Core/GitHub/GitHubApi.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubApi.cs
@@ -72,23 +72,6 @@ internal static class GitHubApi
     }
 
     /// <summary>
-    /// Discards the shared client and cache. Only used by the tests, to keep rate limit state from leaking between them.
-    /// </summary>
-    internal static void Reset()
-    {
-        lock (SharedLock)
-        {
-            foreach (GitHubApiClient client in ClientsByApiKey.Values)
-            {
-                client.Dispose();
-            }
-
-            ClientsByApiKey.Clear();
-            responseCache = null;
-        }
-    }
-
-    /// <summary>
     /// Returns the shared response cache, creating it on first use.
     /// </summary>
     private static GitHubResponseCache GetOrCreateResponseCache(ILogger logger)

--- a/Src/PackageGuard.Core/GitHub/GitHubApiClient.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubApiClient.cs
@@ -1,0 +1,423 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace PackageGuard.Core.GitHub;
+
+/// <summary>
+/// Sends requests to the GitHub API on behalf of every component that needs GitHub data, so that the rate limit
+/// budget, the request concurrency, and the conditional-request cache are shared across the whole run.
+/// </summary>
+/// <remarks>
+/// GitHub enforces a secondary rate limit on concurrent requests on top of the hourly primary limit, and answers
+/// both with <c>403</c> or <c>429</c>. This client keeps concurrency well below that ceiling, honours
+/// <c>retry-after</c>, and stops making requests altogether once the budget is spent, rather than spending the rest
+/// of the run collecting rejections.
+/// </remarks>
+internal sealed class GitHubApiClient : IDisposable
+{
+    private readonly ILogger logger;
+    private readonly string? apiKey;
+    private readonly GitHubResponseCache responseCache;
+    private readonly HttpClient httpClient;
+    private readonly SemaphoreSlim concurrencyGate = new(MaxConcurrentRequests);
+    private readonly Lock exhaustionLock = new();
+
+    private bool isExhausted;
+    private bool hasLoggedExhaustion;
+
+    /// <summary>
+    /// The number of requests allowed to be in flight at the same time. GitHub asks callers to stay below 100
+    /// concurrent requests; staying an order of magnitude below that avoids the secondary rate limit entirely.
+    /// </summary>
+    private const int MaxConcurrentRequests = 8;
+
+    /// <summary>
+    /// The number of times a single request is retried after a throttling or transient server response.
+    /// </summary>
+    private const int MaxAttempts = 3;
+
+    /// <summary>
+    /// The longest a single request waits for a rate limit to clear. A wait beyond this points at the hourly primary
+    /// limit rather than a short burst limit, and the run degrades instead of stalling.
+    /// </summary>
+    private static readonly TimeSpan MaxThrottleWait = TimeSpan.FromSeconds(90);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitHubApiClient"/> class.
+    /// </summary>
+    /// <param name="logger">The logger to report throttling and request failures to.</param>
+    /// <param name="apiKey">The GitHub personal access token to authenticate with, if any.</param>
+    /// <param name="responseCache">The conditional-request cache to revalidate responses against.</param>
+    /// <param name="handler">An optional message handler, used by the tests to avoid real network traffic.</param>
+    public GitHubApiClient(ILogger logger, string? apiKey, GitHubResponseCache? responseCache = null,
+        HttpMessageHandler? handler = null)
+    {
+        this.logger = logger;
+        this.apiKey = apiKey;
+        this.responseCache = responseCache ?? new GitHubResponseCache(logger);
+
+        httpClient = handler is null ? new HttpClient() : new HttpClient(handler);
+        httpClient.Timeout = TimeSpan.FromSeconds(30);
+        httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PackageGuard", "v1"));
+    }
+
+    /// <summary>
+    /// The rate limit budget as last reported by the API.
+    /// </summary>
+    public GitHubRateLimit RateLimit { get; } = new();
+
+    /// <summary>
+    /// The conditional-request cache backing this client.
+    /// </summary>
+    public GitHubResponseCache ResponseCache => responseCache;
+
+    /// <summary>
+    /// Indicates whether the rate limit budget is spent and no further requests will be attempted this run.
+    /// </summary>
+    public bool IsExhausted
+    {
+        get
+        {
+            lock (exhaustionLock)
+            {
+                return isExhausted;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Requests <paramref name="url"/> and returns the parsed response, or <see langword="null"/> when the resource
+    /// does not exist, the request failed, or the rate limit budget no longer allows it.
+    /// </summary>
+    /// <param name="url">The absolute GitHub API URL to request.</param>
+    /// <param name="importance">How valuable the request is when the budget runs low.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    public async Task<JsonDocument?> GetJsonAsync(string url,
+        GitHubRequestImportance importance = GitHubRequestImportance.Essential,
+        CancellationToken cancellationToken = default)
+    {
+        string? body = await GetStringAsync(url, importance, cancellationToken);
+        if (body is null || body.Length == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonDocument.Parse(body);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogDebug(ex, "GitHub returned a malformed response for {Url}", url);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Requests <paramref name="url"/> and returns the raw response body, or <see langword="null"/> when the resource
+    /// does not exist, the request failed, or the rate limit budget no longer allows it.
+    /// </summary>
+    /// <param name="url">The absolute GitHub API URL to request.</param>
+    /// <param name="importance">How valuable the request is when the budget runs low.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    public async Task<string?> GetStringAsync(string url, GitHubRequestImportance importance,
+        CancellationToken cancellationToken = default)
+    {
+        if (!ShouldAttempt(url, importance))
+        {
+            return null;
+        }
+
+        for (int attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            GitHubAttemptResult result = await SendOnceAsync(url, cancellationToken);
+            if (result.IsFinal)
+            {
+                return result.Body;
+            }
+
+            if (!await WaitBeforeRetryAsync(url, result, attempt, cancellationToken))
+            {
+                return null;
+            }
+        }
+
+        logger.LogDebug("Giving up on {Url} after {Attempts} attempts", url, MaxAttempts);
+        return null;
+    }
+
+    /// <summary>
+    /// Returns <see langword="false"/> when the request should not even be attempted, because the budget is spent,
+    /// the budget is down to its reserve and the request is optional, or the resource is known to be missing.
+    /// </summary>
+    private bool ShouldAttempt(string url, GitHubRequestImportance importance)
+    {
+        if (IsExhausted)
+        {
+            return false;
+        }
+
+        if (importance == GitHubRequestImportance.Optional && RateLimit.IsInReserve())
+        {
+            logger.LogDebug("Skipping optional GitHub request {Url}; only {Remaining} requests left before the reset",
+                url, RateLimit.Remaining);
+
+            return false;
+        }
+
+        return !responseCache.IsKnownToBeMissing(url);
+    }
+
+    /// <summary>
+    /// Performs a single attempt, translating the response into either a final answer or a retry instruction.
+    /// </summary>
+    private async Task<GitHubAttemptResult> SendOnceAsync(string url, CancellationToken cancellationToken)
+    {
+        await concurrencyGate.WaitAsync(cancellationToken);
+        try
+        {
+            return await SendAndInterpretAsync(url, cancellationToken);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException &&
+                                  !cancellationToken.IsCancellationRequested)
+        {
+            logger.LogDebug(ex, "GitHub request to {Url} failed", url);
+            return GitHubAttemptResult.Retryable();
+        }
+        finally
+        {
+            concurrencyGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Sends the conditional request and maps the status code onto an attempt result.
+    /// </summary>
+    private async Task<GitHubAttemptResult> SendAndInterpretAsync(string url, CancellationToken cancellationToken)
+    {
+        GitHubResponseCacheEntry? cached = responseCache.Find(url);
+
+        logger.LogDebug("GET {Url}", url);
+        using HttpRequestMessage request = CreateRequest(url, cached?.ETag);
+        using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
+        RateLimit.Update(response.Headers);
+
+        if (response.StatusCode == HttpStatusCode.NotModified && cached is not null)
+        {
+            responseCache.MarkAsRevalidated(url);
+            return GitHubAttemptResult.Final(cached.Body);
+        }
+
+        return response.IsSuccessStatusCode
+            ? GitHubAttemptResult.Final(await StoreSuccessAsync(url, response, cancellationToken))
+            : InterpretFailure(url, response);
+    }
+
+    /// <summary>
+    /// Reads and caches the body of a successful response.
+    /// </summary>
+    private async Task<string> StoreSuccessAsync(string url, HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+        responseCache.StoreResponse(url, response.Headers.ETag?.ToString(), body);
+        return body;
+    }
+
+    /// <summary>
+    /// Maps an unsuccessful response onto an attempt result, remembering missing resources and recognising throttling.
+    /// </summary>
+    private GitHubAttemptResult InterpretFailure(string url, HttpResponseMessage response)
+    {
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            responseCache.StoreNotFound(url);
+            return GitHubAttemptResult.Final(null);
+        }
+
+        if (IsThrottled(response))
+        {
+            return GitHubAttemptResult.Throttled(ReadRetryAfter(response));
+        }
+
+        if ((int)response.StatusCode >= 500)
+        {
+            logger.LogDebug("GitHub returned {StatusCode} for {Url}", (int)response.StatusCode, url);
+            return GitHubAttemptResult.Retryable();
+        }
+
+        logger.LogDebug("GitHub returned {StatusCode} for {Url}", (int)response.StatusCode, url);
+        return GitHubAttemptResult.Final(null);
+    }
+
+    /// <summary>
+    /// Waits for the delay a throttled or transient response asks for, and reports whether retrying is still viable.
+    /// </summary>
+    private async Task<bool> WaitBeforeRetryAsync(string url, GitHubAttemptResult result, int attempt,
+        CancellationToken cancellationToken)
+    {
+        if (!result.IsThrottled)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(attempt), cancellationToken);
+            return true;
+        }
+
+        TimeSpan delay = result.RetryAfter ?? RateLimit.TimeUntilReset(DateTimeOffset.UtcNow) ??
+            TimeSpan.FromSeconds(attempt * 2);
+
+        if (delay > MaxThrottleWait)
+        {
+            ReportExhaustion(delay);
+            return false;
+        }
+
+        logger.LogDebug("GitHub throttled {Url}; waiting {Delay} before retrying", url, delay);
+        await Task.Delay(delay, cancellationToken);
+        return true;
+    }
+
+    /// <summary>
+    /// Stops all further requests for this run and explains to the user how to lift the limit.
+    /// </summary>
+    private void ReportExhaustion(TimeSpan delay)
+    {
+        lock (exhaustionLock)
+        {
+            isExhausted = true;
+            if (hasLoggedExhaustion)
+            {
+                return;
+            }
+
+            hasLoggedExhaustion = true;
+        }
+
+        LogExhaustion(delay);
+    }
+
+    /// <summary>
+    /// Writes the one-off warning that explains why GitHub data is missing from the results.
+    /// </summary>
+    private void LogExhaustion(TimeSpan delay)
+    {
+        if (apiKey is null)
+        {
+            logger.LogWarning(
+                "The GitHub API rate limit is exhausted and resets in {Minutes} minutes. Unauthenticated callers get " +
+                "only 60 requests per hour. Pass a personal access token through --github-api-key or the " +
+                "GITHUB_API_KEY environment variable to raise the limit to 5000 requests per hour. GitHub-based " +
+                "signals are left empty for the remaining packages.",
+                Math.Ceiling(delay.TotalMinutes));
+        }
+        else
+        {
+            logger.LogWarning(
+                "The GitHub API rate limit is exhausted and resets in {Minutes} minutes. GitHub-based signals are " +
+                "left empty for the remaining packages. Re-run after the reset to complete the report.",
+                Math.Ceiling(delay.TotalMinutes));
+        }
+    }
+
+    /// <summary>
+    /// Builds a request carrying the GitHub media type, the token when configured, and the cached entity tag.
+    /// </summary>
+    private HttpRequestMessage CreateRequest(string url, string? eTag)
+    {
+        HttpRequestMessage request = new(HttpMethod.Get, url);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        }
+
+        if (!string.IsNullOrWhiteSpace(eTag))
+        {
+            request.Headers.TryAddWithoutValidation("If-None-Match", eTag);
+        }
+
+        return request;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the response signals a primary or secondary rate limit rather than a
+    /// permission problem. Both arrive as <c>403</c> or <c>429</c>, distinguished by the rate limit headers.
+    /// </summary>
+    private static bool IsThrottled(HttpResponseMessage response)
+    {
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            return true;
+        }
+
+        if (response.StatusCode != HttpStatusCode.Forbidden)
+        {
+            return false;
+        }
+
+        return response.Headers.Contains("retry-after") || ReadRemaining(response) == 0;
+    }
+
+    /// <summary>
+    /// Reads the <c>retry-after</c> header as a delay, when present.
+    /// </summary>
+    private static TimeSpan? ReadRetryAfter(HttpResponseMessage response)
+    {
+        RetryConditionHeaderValue? retryAfter = response.Headers.RetryAfter;
+        if (retryAfter?.Delta is not null)
+        {
+            return retryAfter.Delta;
+        }
+
+        return retryAfter?.Date is null ? null : retryAfter.Date.Value - DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Reads the remaining request budget straight off a response, independent of the tracked state.
+    /// </summary>
+    private static int? ReadRemaining(HttpResponseMessage response)
+    {
+        if (!response.Headers.TryGetValues("x-ratelimit-remaining", out IEnumerable<string>? values))
+        {
+            return null;
+        }
+
+        return int.TryParse(values.FirstOrDefault(), out int remaining) ? remaining : null;
+    }
+
+    /// <summary>
+    /// Releases the underlying HTTP client and concurrency gate.
+    /// </summary>
+    public void Dispose()
+    {
+        httpClient.Dispose();
+        concurrencyGate.Dispose();
+    }
+
+    /// <summary>
+    /// The outcome of a single request attempt.
+    /// </summary>
+    /// <param name="IsFinal">Indicates that no further attempt should be made.</param>
+    /// <param name="Body">The response body when the attempt succeeded.</param>
+    /// <param name="IsThrottled">Indicates that GitHub rejected the attempt because of a rate limit.</param>
+    /// <param name="RetryAfter">The delay GitHub asked the caller to wait, when it supplied one.</param>
+    private sealed record GitHubAttemptResult(bool IsFinal, string? Body, bool IsThrottled, TimeSpan? RetryAfter)
+    {
+        /// <summary>
+        /// Creates a result that ends the retry loop.
+        /// </summary>
+        public static GitHubAttemptResult Final(string? body) => new(true, body, false, null);
+
+        /// <summary>
+        /// Creates a result asking for another attempt after a short backoff.
+        /// </summary>
+        public static GitHubAttemptResult Retryable() => new(false, null, false, null);
+
+        /// <summary>
+        /// Creates a result asking for another attempt once the rate limit clears.
+        /// </summary>
+        public static GitHubAttemptResult Throttled(TimeSpan? retryAfter) => new(false, null, true, retryAfter);
+    }
+}

--- a/Src/PackageGuard.Core/GitHub/GitHubApiClient.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubApiClient.cs
@@ -24,6 +24,11 @@ internal sealed class GitHubApiClient : IDisposable
     private readonly SemaphoreSlim concurrencyGate = new(MaxConcurrentRequests);
     private readonly Lock exhaustionLock = new();
 
+    /// <summary>
+    /// The rate limit budget as last reported by the API.
+    /// </summary>
+    private readonly GitHubRateLimit rateLimit = new();
+
     private bool isExhausted;
     private bool hasLoggedExhaustion;
 
@@ -64,16 +69,6 @@ internal sealed class GitHubApiClient : IDisposable
     }
 
     /// <summary>
-    /// The rate limit budget as last reported by the API.
-    /// </summary>
-    public GitHubRateLimit RateLimit { get; } = new();
-
-    /// <summary>
-    /// The conditional-request cache backing this client.
-    /// </summary>
-    public GitHubResponseCache ResponseCache => responseCache;
-
-    /// <summary>
     /// Indicates whether the rate limit budget is spent and no further requests will be attempted this run.
     /// </summary>
     public bool IsExhausted
@@ -99,7 +94,7 @@ internal sealed class GitHubApiClient : IDisposable
         CancellationToken cancellationToken = default)
     {
         string? body = await GetStringAsync(url, importance, cancellationToken);
-        if (body is null || body.Length == 0)
+        if (string.IsNullOrEmpty(body))
         {
             return null;
         }
@@ -122,7 +117,7 @@ internal sealed class GitHubApiClient : IDisposable
     /// <param name="url">The absolute GitHub API URL to request.</param>
     /// <param name="importance">How valuable the request is when the budget runs low.</param>
     /// <param name="cancellationToken">Cancels the request.</param>
-    public async Task<string?> GetStringAsync(string url, GitHubRequestImportance importance,
+    private async Task<string?> GetStringAsync(string url, GitHubRequestImportance importance,
         CancellationToken cancellationToken = default)
     {
         if (!ShouldAttempt(url, importance))
@@ -159,10 +154,10 @@ internal sealed class GitHubApiClient : IDisposable
             return false;
         }
 
-        if (importance == GitHubRequestImportance.Optional && RateLimit.IsInReserve())
+        if (importance == GitHubRequestImportance.Optional && rateLimit.IsInReserve())
         {
             logger.LogDebug("Skipping optional GitHub request {Url}; only {Remaining} requests left before the reset",
-                url, RateLimit.Remaining);
+                url, rateLimit.Remaining);
 
             return false;
         }
@@ -202,7 +197,7 @@ internal sealed class GitHubApiClient : IDisposable
         logger.LogDebug("GET {Url}", url);
         using HttpRequestMessage request = CreateRequest(url, cached?.ETag);
         using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
-        RateLimit.Update(response.Headers);
+        rateLimit.Update(response.Headers);
 
         if (response.StatusCode == HttpStatusCode.NotModified && cached is not null)
         {
@@ -258,13 +253,13 @@ internal sealed class GitHubApiClient : IDisposable
     private async Task<bool> WaitBeforeRetryAsync(string url, GitHubAttemptResult result, int attempt,
         CancellationToken cancellationToken)
     {
-        if (!result.IsThrottled)
+        if (!result.WasThrottled)
         {
             await Task.Delay(TimeSpan.FromSeconds(attempt), cancellationToken);
             return true;
         }
 
-        TimeSpan delay = result.RetryAfter ?? RateLimit.TimeUntilReset(DateTimeOffset.UtcNow) ??
+        TimeSpan delay = result.RetryAfter ?? rateLimit.TimeUntilReset(DateTimeOffset.UtcNow) ??
             TimeSpan.FromSeconds(attempt * 2);
 
         if (delay > MaxThrottleWait)
@@ -401,9 +396,9 @@ internal sealed class GitHubApiClient : IDisposable
     /// </summary>
     /// <param name="IsFinal">Indicates that no further attempt should be made.</param>
     /// <param name="Body">The response body when the attempt succeeded.</param>
-    /// <param name="IsThrottled">Indicates that GitHub rejected the attempt because of a rate limit.</param>
+    /// <param name="WasThrottled">Indicates that GitHub rejected the attempt because of a rate limit.</param>
     /// <param name="RetryAfter">The delay GitHub asked the caller to wait, when it supplied one.</param>
-    private sealed record GitHubAttemptResult(bool IsFinal, string? Body, bool IsThrottled, TimeSpan? RetryAfter)
+    private sealed record GitHubAttemptResult(bool IsFinal, string? Body, bool WasThrottled, TimeSpan? RetryAfter)
     {
         /// <summary>
         /// Creates a result that ends the retry loop.

--- a/Src/PackageGuard.Core/GitHub/GitHubRateLimit.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubRateLimit.cs
@@ -35,7 +35,7 @@ internal sealed class GitHubRateLimit
     /// <summary>
     /// The moment at which the current rate limit window resets, or <see langword="null"/> when unknown.
     /// </summary>
-    public DateTimeOffset? ResetsAt
+    private DateTimeOffset? ResetsAt
     {
         get
         {
@@ -50,7 +50,7 @@ internal sealed class GitHubRateLimit
     /// The number of requests held back for essential calls. Optional calls are skipped once the remaining budget
     /// drops to this level, so that the signals that matter most still get through.
     /// </summary>
-    public int Reserve
+    private int Reserve
     {
         get
         {

--- a/Src/PackageGuard.Core/GitHub/GitHubRateLimit.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubRateLimit.cs
@@ -1,0 +1,132 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+
+namespace PackageGuard.Core.GitHub;
+
+/// <summary>
+/// Tracks the primary rate limit budget reported by the GitHub API through its <c>x-ratelimit-*</c> response headers.
+/// </summary>
+internal sealed class GitHubRateLimit
+{
+    /// <summary>
+    /// Guards concurrent reads and writes of the mutable budget fields.
+    /// </summary>
+    private readonly Lock stateLock = new();
+
+    private int? limit;
+    private int? remaining;
+    private DateTimeOffset? resetsAt;
+
+    /// <summary>
+    /// The number of requests still available in the current rate limit window, or <see langword="null"/> when the
+    /// API has not reported a budget yet.
+    /// </summary>
+    public int? Remaining
+    {
+        get
+        {
+            lock (stateLock)
+            {
+                return remaining;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The moment at which the current rate limit window resets, or <see langword="null"/> when unknown.
+    /// </summary>
+    public DateTimeOffset? ResetsAt
+    {
+        get
+        {
+            lock (stateLock)
+            {
+                return resetsAt;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The number of requests held back for essential calls. Optional calls are skipped once the remaining budget
+    /// drops to this level, so that the signals that matter most still get through.
+    /// </summary>
+    public int Reserve
+    {
+        get
+        {
+            lock (stateLock)
+            {
+                return limit is null ? DefaultReserve : Math.Max(DefaultReserve, limit.Value / 20);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The reserve applied when the API has not reported a rate limit ceiling yet.
+    /// </summary>
+    private const int DefaultReserve = 10;
+
+    /// <summary>
+    /// Records the rate limit budget advertised by a GitHub API response.
+    /// </summary>
+    /// <param name="headers">The response headers to read the <c>x-ratelimit-*</c> values from.</param>
+    public void Update(HttpResponseHeaders headers)
+    {
+        lock (stateLock)
+        {
+            limit = TryReadInt(headers, "x-ratelimit-limit") ?? limit;
+            remaining = TryReadInt(headers, "x-ratelimit-remaining") ?? remaining;
+            resetsAt = TryReadReset(headers) ?? resetsAt;
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the remaining budget has dropped into the reserve, meaning optional
+    /// requests should be skipped.
+    /// </summary>
+    public bool IsInReserve()
+    {
+        lock (stateLock)
+        {
+            return remaining is not null && remaining.Value <= Reserve;
+        }
+    }
+
+    /// <summary>
+    /// Returns how long to wait before the rate limit window resets, or <see langword="null"/> when the reset time
+    /// is unknown or already in the past.
+    /// </summary>
+    public TimeSpan? TimeUntilReset(DateTimeOffset now)
+    {
+        DateTimeOffset? reset = ResetsAt;
+        if (reset is null || reset.Value <= now)
+        {
+            return null;
+        }
+
+        return reset.Value - now;
+    }
+
+    /// <summary>
+    /// Reads a single integer header value, returning <see langword="null"/> when it is absent or malformed.
+    /// </summary>
+    private static int? TryReadInt(HttpResponseHeaders headers, string name)
+    {
+        if (!headers.TryGetValues(name, out IEnumerable<string>? values))
+        {
+            return null;
+        }
+
+        string? raw = values.FirstOrDefault();
+        return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed) ? parsed : null;
+    }
+
+    /// <summary>
+    /// Reads the <c>x-ratelimit-reset</c> header, which carries the reset moment as Unix seconds.
+    /// </summary>
+    private static DateTimeOffset? TryReadReset(HttpResponseHeaders headers)
+    {
+        int? epochSeconds = TryReadInt(headers, "x-ratelimit-reset");
+        return epochSeconds is null ? null : DateTimeOffset.FromUnixTimeSeconds(epochSeconds.Value);
+    }
+}

--- a/Src/PackageGuard.Core/GitHub/GitHubRequestImportance.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubRequestImportance.cs
@@ -1,0 +1,20 @@
+namespace PackageGuard.Core.GitHub;
+
+/// <summary>
+/// Describes how valuable a GitHub API request is, which decides whether it still gets made once the rate limit
+/// budget runs low.
+/// </summary>
+internal enum GitHubRequestImportance
+{
+    /// <summary>
+    /// The request carries a signal that the rest of the analysis depends on and is attempted for as long as the
+    /// rate limit allows any request at all.
+    /// </summary>
+    Essential,
+
+    /// <summary>
+    /// The request refines a risk signal but is not worth spending the last of the rate limit budget on. Requests of
+    /// this kind are skipped once the remaining budget drops into the reserve.
+    /// </summary>
+    Optional
+}

--- a/Src/PackageGuard.Core/GitHub/GitHubResponseCache.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubResponseCache.cs
@@ -1,0 +1,197 @@
+using System.IO.Compression;
+using MemoryPack;
+using Microsoft.Extensions.Logging;
+using Pathy;
+
+namespace PackageGuard.Core.GitHub;
+
+/// <summary>
+/// Stores GitHub API responses together with their entity tags so that later runs can revalidate them with a
+/// conditional request. GitHub does not charge a <c>304 Not Modified</c> against the primary rate limit of an
+/// authenticated caller, which makes repeated runs far cheaper.
+/// </summary>
+internal sealed class GitHubResponseCache(ILogger logger)
+{
+    /// <summary>
+    /// Cached responses keyed by request URL.
+    /// </summary>
+    private readonly Dictionary<string, GitHubResponseCacheEntry> entries = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Guards concurrent access to <see cref="entries"/>.
+    /// </summary>
+    private readonly Lock entriesLock = new();
+
+    /// <summary>
+    /// Responses larger than this are not persisted, keeping the cache file to a sensible size.
+    /// </summary>
+    private const int MaxCacheableBodyLength = 512 * 1024;
+
+    /// <summary>
+    /// How long a "resource does not exist" answer is trusted before it is probed again.
+    /// </summary>
+    private static readonly TimeSpan NotFoundLifetime = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// Returns the cached entry for <paramref name="url"/>, or <see langword="null"/> when nothing is cached.
+    /// </summary>
+    public GitHubResponseCacheEntry? Find(string url)
+    {
+        lock (entriesLock)
+        {
+            if (!entries.TryGetValue(url, out GitHubResponseCacheEntry? entry))
+            {
+                return null;
+            }
+
+            entry.IsUsed = true;
+            return entry;
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when a recent request established that <paramref name="url"/> does not exist.
+    /// </summary>
+    public bool IsKnownToBeMissing(string url)
+    {
+        GitHubResponseCacheEntry? entry = Find(url);
+        return entry is { IsNotFound: true } && DateTimeOffset.UtcNow - entry.StoredAt <= NotFoundLifetime;
+    }
+
+    /// <summary>
+    /// Stores a successful response body and its entity tag.
+    /// </summary>
+    public void StoreResponse(string url, string? eTag, string body)
+    {
+        if (body.Length > MaxCacheableBodyLength)
+        {
+            Remove(url);
+            return;
+        }
+
+        Store(url, entry =>
+        {
+            entry.ETag = eTag;
+            entry.Body = body;
+            entry.IsNotFound = false;
+        });
+    }
+
+    /// <summary>
+    /// Records that <paramref name="url"/> does not exist, so the same probe is not repeated on every run.
+    /// </summary>
+    public void StoreNotFound(string url) => Store(url, entry =>
+    {
+        entry.ETag = null;
+        entry.Body = string.Empty;
+        entry.IsNotFound = true;
+    });
+
+    /// <summary>
+    /// Refreshes the revalidation timestamp of an entry that the API confirmed as unchanged.
+    /// </summary>
+    public void MarkAsRevalidated(string url) => Store(url, _ => { });
+
+    /// <summary>
+    /// Loads previously persisted responses from <paramref name="cacheFilePath"/>, ignoring a missing or unreadable file.
+    /// </summary>
+    public async Task LoadAsync(string cacheFilePath)
+    {
+        if (!File.Exists(cacheFilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            GitHubResponseCacheEntry[] loaded = await ReadEntriesAsync(cacheFilePath);
+            lock (entriesLock)
+            {
+                foreach (GitHubResponseCacheEntry entry in loaded)
+                {
+                    entries[entry.Url] = entry;
+                }
+            }
+
+            logger.LogDebug("Loaded {Count} cached GitHub responses from {CacheFilePath}", loaded.Length, cacheFilePath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Could not load the GitHub response cache from {CacheFilePath}", cacheFilePath);
+        }
+    }
+
+    /// <summary>
+    /// Persists every entry that was used during this run to <paramref name="cacheFilePath"/>.
+    /// </summary>
+    public async Task SaveAsync(string cacheFilePath)
+    {
+        GitHubResponseCacheEntry[] used;
+        lock (entriesLock)
+        {
+            used = entries.Values.Where(entry => entry.IsUsed).ToArray();
+        }
+
+        try
+        {
+            cacheFilePath.ToPath().Directory.CreateDirectoryRecursively();
+            await WriteEntriesAsync(cacheFilePath, used);
+            logger.LogDebug("Persisted {Count} cached GitHub responses to {CacheFilePath}", used.Length, cacheFilePath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Could not persist the GitHub response cache to {CacheFilePath}", cacheFilePath);
+        }
+    }
+
+    /// <summary>
+    /// Reads and decompresses the persisted entries.
+    /// </summary>
+    private static async Task<GitHubResponseCacheEntry[]> ReadEntriesAsync(string cacheFilePath)
+    {
+        await using FileStream fileStream = new(cacheFilePath, FileMode.Open, FileAccess.Read);
+        await using BrotliStream decompressor = new(fileStream, CompressionMode.Decompress);
+        return await MemoryPackSerializer.DeserializeAsync<GitHubResponseCacheEntry[]>(decompressor) ?? [];
+    }
+
+    /// <summary>
+    /// Compresses and writes the given entries.
+    /// </summary>
+    private static async Task WriteEntriesAsync(string cacheFilePath, GitHubResponseCacheEntry[] used)
+    {
+        await using FileStream fileStream = new(cacheFilePath, FileMode.Create, FileAccess.Write);
+        await using BrotliStream compressor = new(fileStream, CompressionLevel.Fastest);
+        await MemoryPackSerializer.SerializeAsync(compressor, used);
+    }
+
+    /// <summary>
+    /// Applies <paramref name="update"/> to the entry for <paramref name="url"/>, creating it when needed, and stamps
+    /// it as freshly revalidated.
+    /// </summary>
+    private void Store(string url, Action<GitHubResponseCacheEntry> update)
+    {
+        lock (entriesLock)
+        {
+            if (!entries.TryGetValue(url, out GitHubResponseCacheEntry? entry))
+            {
+                entry = new GitHubResponseCacheEntry { Url = url };
+                entries[url] = entry;
+            }
+
+            update(entry);
+            entry.StoredAt = DateTimeOffset.UtcNow;
+            entry.IsUsed = true;
+        }
+    }
+
+    /// <summary>
+    /// Drops the entry for <paramref name="url"/>, if any.
+    /// </summary>
+    private void Remove(string url)
+    {
+        lock (entriesLock)
+        {
+            entries.Remove(url);
+        }
+    }
+}

--- a/Src/PackageGuard.Core/GitHub/GitHubResponseCacheEntry.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubResponseCacheEntry.cs
@@ -1,0 +1,43 @@
+using MemoryPack;
+
+namespace PackageGuard.Core.GitHub;
+
+/// <summary>
+/// A single cached GitHub API response, used to revalidate the resource with a conditional request instead of
+/// downloading it again.
+/// </summary>
+[MemoryPackable]
+internal sealed partial class GitHubResponseCacheEntry
+{
+    /// <summary>
+    /// The absolute request URL this entry was stored for.
+    /// </summary>
+    public required string Url { get; init; }
+
+    /// <summary>
+    /// The entity tag returned with the response, replayed as <c>If-None-Match</c> on the next request.
+    /// </summary>
+    public string? ETag { get; set; }
+
+    /// <summary>
+    /// The response body, or an empty string when the response carried no content.
+    /// </summary>
+    public string Body { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Indicates that the resource did not exist when it was last requested.
+    /// </summary>
+    public bool IsNotFound { get; set; }
+
+    /// <summary>
+    /// The moment the entry was last revalidated against the API.
+    /// </summary>
+    public DateTimeOffset StoredAt { get; set; }
+
+    /// <summary>
+    /// Indicates whether the entry was read or written during the current run. Entries left untouched are dropped
+    /// when the cache is persisted, so the file does not grow without bound.
+    /// </summary>
+    [MemoryPackIgnore]
+    public bool IsUsed { get; set; }
+}

--- a/Src/PackageGuard.Core/ProjectAnalyzer.cs
+++ b/Src/PackageGuard.Core/ProjectAnalyzer.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using PackageGuard.Core.Common;
 using PackageGuard.Core.CSharp;
+using PackageGuard.Core.GitHub;
 using PackageGuard.Core.Npm;
 using PackageGuard.Core.Package;
 using PackageGuard.Core.Policy;
@@ -46,10 +47,12 @@ public class ProjectAnalyzer(LicenseFetcher licenseFetcher, RiskEvaluator? riskE
         List<PolicyViolation> violations = new();
 
         PackageInfoCollection packages = new(Logger, settings);
-        if (settings is { UseCaching: true, CacheFilePath.Length: > 0 })
+        bool isCachingEnabled = settings is { UseCaching: true, CacheFilePath.Length: > 0 };
+        if (isCachingEnabled)
         {
             Logger.LogInformation("Try loading package cache from {CacheFilePath}", settings.CacheFilePath);
             await packages.TryInitializeFromCache(settings.CacheFilePath);
+            await GitHubApi.LoadResponseCacheAsync(Logger, settings.CacheFilePath);
         }
 
         foreach (IProjectAnalysisStrategy strategy in strategies)
@@ -67,6 +70,11 @@ public class ProjectAnalyzer(LicenseFetcher licenseFetcher, RiskEvaluator? riskE
         if (settings.UseCaching)
         {
             await packages.WriteToCache(settings.CacheFilePath);
+        }
+
+        if (isCachingEnabled)
+        {
+            await GitHubApi.SaveResponseCacheAsync(Logger, settings.CacheFilePath);
         }
 
         return new AnalysisResult

--- a/Src/PackageGuard.Core/Risk/Enrichment/GitHubRepositoryRiskEnricher.cs
+++ b/Src/PackageGuard.Core/Risk/Enrichment/GitHubRepositoryRiskEnricher.cs
@@ -343,8 +343,7 @@ internal sealed class GitHubRepositoryRiskEnricher : IEnrichPackageRisk
     }
 
     /// <summary>Requests a document that the repository's risk profile depends on.</summary>
-    private Task<JsonDocument?> GetJsonAsync(string url) =>
-        apiClient.GetJsonAsync(url, GitHubRequestImportance.Essential);
+    private Task<JsonDocument?> GetJsonAsync(string url) => apiClient.GetJsonAsync(url);
 
     /// <summary>
     /// Requests a document that refines a single risk signal. Requests like these are dropped once the rate limit

--- a/Src/PackageGuard.Core/Risk/Enrichment/GitHubRepositoryRiskEnricher.cs
+++ b/Src/PackageGuard.Core/Risk/Enrichment/GitHubRepositoryRiskEnricher.cs
@@ -1,21 +1,19 @@
-using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
+using PackageGuard.Core.GitHub;
 using PackageGuard.Core.Package;
 
 namespace PackageGuard.Core.Risk.Enrichment;
 
 /// <summary>Enriches package risk data using GitHub repository API metadata.</summary>
-internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHubApiKey) : IEnrichPackageRisk
+internal sealed class GitHubRepositoryRiskEnricher : IEnrichPackageRisk
 {
-    /// <summary>Shared HTTP client for GitHub API requests.</summary>
-    private static readonly HttpClient HttpClient = new();
-
-    /// <summary>Cache of repository API root URL to risk data.</summary>
+    /// <summary>Cache of repository API root URL to risk data. A cached <c>null</c> records a repository whose data
+    /// could not be fetched, so the packages that follow do not repeat the same failing fan-out.</summary>
     private static readonly Dictionary<string, GitHubRepositoryRiskData?> Cache = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>In-flight load tasks per repository API root, preventing duplicate concurrent fetches.</summary>
@@ -25,10 +23,37 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     /// <summary>Lock for thread-safe cache and in-flight loads access.</summary>
     private static readonly Lock CacheLock = new();
 
-    /// <summary>Static constructor that sets the User-Agent header.</summary>
-    static GitHubRepositoryRiskEnricher()
+    /// <summary>Client for the OpenSSF Scorecard API, which is not subject to the GitHub rate limit.</summary>
+    private static readonly HttpClient ScorecardHttpClient = new() { Timeout = TimeSpan.FromSeconds(20) };
+
+    private readonly ILogger logger;
+    private readonly GitHubApiClient apiClient;
+
+    /// <summary>Creates an enricher that talks to GitHub through the client shared by the whole run.</summary>
+    /// <param name="logger">The logger to report fetch problems to.</param>
+    /// <param name="gitHubApiKey">The GitHub personal access token to authenticate with, if any.</param>
+    public GitHubRepositoryRiskEnricher(ILogger logger, string? gitHubApiKey)
+        : this(logger, GitHubApi.GetOrCreateClient(logger, gitHubApiKey))
     {
-        HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PackageGuard", "v1"));
+    }
+
+    /// <summary>Creates an enricher that talks to GitHub through the given client.</summary>
+    /// <param name="logger">The logger to report fetch problems to.</param>
+    /// <param name="apiClient">The client to send GitHub API requests through.</param>
+    internal GitHubRepositoryRiskEnricher(ILogger logger, GitHubApiClient apiClient)
+    {
+        this.logger = logger;
+        this.apiClient = apiClient;
+    }
+
+    /// <summary>Discards the cross-package repository cache. Only used by the tests.</summary>
+    internal static void ClearCache()
+    {
+        lock (CacheLock)
+        {
+            Cache.Clear();
+            InFlightLoads.Clear();
+        }
     }
 
     /// <summary>Returns true if GitHub risk data is already populated for the package.</summary>
@@ -133,7 +158,7 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
 
         lock (CacheLock)
         {
-            if (Cache.TryGetValue(repositoryApiRoot, out GitHubRepositoryRiskData? cached) && cached != null)
+            if (Cache.TryGetValue(repositoryApiRoot, out GitHubRepositoryRiskData? cached))
             {
                 return cached;
             }
@@ -150,11 +175,7 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
         lock (CacheLock)
         {
             InFlightLoads.Remove(repositoryApiRoot);
-
-            if (loaded != null)
-            {
-                Cache[repositoryApiRoot] = loaded;
-            }
+            Cache[repositoryApiRoot] = loaded;
         }
 
         return loaded;
@@ -165,7 +186,12 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument repoDocument = await GetJsonAsync(repositoryApiRoot);
+            using JsonDocument? repoDocument = await GetJsonAsync(repositoryApiRoot);
+            if (repoDocument is null)
+            {
+                return null;
+            }
+
             JsonElement repo = repoDocument.RootElement;
 
             string defaultBranch = repo.TryGetProperty("default_branch", out JsonElement defaultBranchElement)
@@ -181,21 +207,18 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
                 ? htmlUrlElement.GetString() ?? string.Empty
                 : string.Empty;
 
-            using JsonDocument ownerDocument = await GetJsonAsync(ownerIsOrganization
+            using JsonDocument? ownerDocument = await GetJsonAsync(ownerIsOrganization
                 ? $"https://api.github.com/orgs/{ownerLogin}"
                 : $"https://api.github.com/users/{ownerLogin}");
 
-            DateTimeOffset? ownerCreatedAt = TryReadDate(ownerDocument.RootElement, "created_at");
+            DateTimeOffset? ownerCreatedAt = ownerDocument is null
+                ? null
+                : TryReadDate(ownerDocument.RootElement, "created_at");
 
             var ownerContext = new RepositoryOwnerContext(
                 ownerLogin, repositoryName, ownerIsOrganization, canonicalUrl, ownerCreatedAt);
 
             return await FetchAndAssembleRepositoryDataAsync(repositoryApiRoot, defaultBranch, ownerContext);
-        }
-        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
-        {
-            logger.LogWarning(ex, "Failed to fetch GitHub repository risk metadata from {RepositoryApiRoot}", repositoryApiRoot);
-            return null;
         }
         catch (Exception ex)
         {
@@ -319,30 +342,24 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
         };
     }
 
-    /// <summary>Sends an authenticated GET request and parses the JSON response.</summary>
-    private async Task<JsonDocument> GetJsonAsync(string url)
-    {
-        logger.LogDebug("GET {Url}", url);
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+    /// <summary>Requests a document that the repository's risk profile depends on.</summary>
+    private Task<JsonDocument?> GetJsonAsync(string url) =>
+        apiClient.GetJsonAsync(url, GitHubRequestImportance.Essential);
 
-        if (!string.IsNullOrWhiteSpace(gitHubApiKey))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", gitHubApiKey);
-        }
-
-        using HttpResponseMessage response = await HttpClient.SendAsync(request);
-        response.EnsureSuccessStatusCode();
-        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-    }
+    /// <summary>
+    /// Requests a document that refines a single risk signal. Requests like these are dropped once the rate limit
+    /// budget runs low, so that the repositories still to be scanned keep getting their essential signals.
+    /// </summary>
+    private Task<JsonDocument?> GetOptionalJsonAsync(string url) =>
+        apiClient.GetJsonAsync(url, GitHubRequestImportance.Optional);
 
     /// <summary>Lists filenames in the repository root directory.</summary>
     private async Task<string[]> GetRootFilesAsync(string repositoryApiRoot, string defaultBranch)
     {
-        using JsonDocument contents =
+        using JsonDocument? contents =
             await GetJsonAsync($"{repositoryApiRoot}/contents?ref={Uri.EscapeDataString(defaultBranch)}");
 
-        if (contents.RootElement.ValueKind != JsonValueKind.Array)
+        if (contents?.RootElement.ValueKind != JsonValueKind.Array)
         {
             return [];
         }
@@ -359,7 +376,15 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument readmeDoc = await GetJsonAsync($"{repositoryApiRoot}/readme");
+            using JsonDocument? readmeDoc = await GetJsonAsync($"{repositoryApiRoot}/readme");
+            if (readmeDoc is null)
+            {
+                return new GitHubReadmeData
+                {
+                    Exists = false
+                };
+            }
+
             string content = string.Empty;
 
             if (readmeDoc.RootElement.TryGetProperty("content", out JsonElement contentElement))
@@ -404,8 +429,8 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     /// <summary>Fetches contributor list and computes concentration metrics.</summary>
     private async Task<GitHubContributorData> GetContributorDataAsync(string repositoryApiRoot)
     {
-        using JsonDocument contributorsDoc = await GetJsonAsync($"{repositoryApiRoot}/contributors?per_page=100");
-        if (contributorsDoc.RootElement.ValueKind != JsonValueKind.Array)
+        using JsonDocument? contributorsDoc = await GetJsonAsync($"{repositoryApiRoot}/contributors?per_page=100");
+        if (contributorsDoc?.RootElement.ValueKind != JsonValueKind.Array)
         {
             return new GitHubContributorData();
         }
@@ -440,8 +465,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     /// <summary>Fetches open and closed bug issues and computes issue health metrics.</summary>
     private async Task<GitHubIssueData> GetIssueDataAsync(string repositoryApiRoot)
     {
-        using JsonDocument issuesDoc = await GetJsonAsync($"{repositoryApiRoot}/issues?state=open&labels=bug&per_page=100");
-        if (issuesDoc.RootElement.ValueKind != JsonValueKind.Array)
+        using JsonDocument? issuesDoc =
+            await GetJsonAsync($"{repositoryApiRoot}/issues?state=open&labels=bug&per_page=100");
+
+        if (issuesDoc?.RootElement.ValueKind != JsonValueKind.Array)
         {
             return new GitHubIssueData();
         }
@@ -527,8 +554,8 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
 
         try
         {
-            using JsonDocument commentsDoc = await GetJsonAsync(issue.CommentsUrl);
-            if (commentsDoc.RootElement.ValueKind != JsonValueKind.Array)
+            using JsonDocument? commentsDoc = await GetOptionalJsonAsync(issue.CommentsUrl);
+            if (commentsDoc?.RootElement.ValueKind != JsonValueKind.Array)
             {
                 return new GitHubIssueResponseData();
             }
@@ -558,10 +585,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     /// <summary>Fetches merged PRs and computes median merge time in days.</summary>
     private async Task<double?> GetMedianPullRequestMergeDaysAsync(string repositoryApiRoot)
     {
-        using JsonDocument pullsDoc =
+        using JsonDocument? pullsDoc =
             await GetJsonAsync($"{repositoryApiRoot}/pulls?state=closed&sort=updated&direction=desc&per_page=100");
 
-        if (pullsDoc.RootElement.ValueKind != JsonValueKind.Array)
+        if (pullsDoc?.RootElement.ValueKind != JsonValueKind.Array)
         {
             return null;
         }
@@ -587,8 +614,8 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument releaseDoc = await GetJsonAsync($"{repositoryApiRoot}/releases?per_page=10");
-            if (releaseDoc.RootElement.ValueKind != JsonValueKind.Array)
+            using JsonDocument? releaseDoc = await GetJsonAsync($"{repositoryApiRoot}/releases?per_page=10");
+            if (releaseDoc?.RootElement.ValueKind != JsonValueKind.Array)
             {
                 return new GitHubReleaseData();
             }
@@ -679,10 +706,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument pullsDoc =
+            using JsonDocument? pullsDoc =
                 await GetJsonAsync($"{repositoryApiRoot}/pulls?state=closed&sort=updated&direction=desc&per_page=30");
 
-            if (pullsDoc.RootElement.ValueKind != JsonValueKind.Array)
+            if (pullsDoc?.RootElement.ValueKind != JsonValueKind.Array)
             {
                 return new GitHubPullRequestQualityData();
             }
@@ -749,10 +776,11 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument workflowsDoc = await GetJsonAsync(
+            using JsonDocument? workflowsDoc = await GetJsonAsync(
                 $"{repositoryApiRoot}/actions/runs?branch={Uri.EscapeDataString(defaultBranch)}&per_page=10");
 
-            if (!workflowsDoc.RootElement.TryGetProperty("workflow_runs", out JsonElement runs) ||
+            if (workflowsDoc is null ||
+                !workflowsDoc.RootElement.TryGetProperty("workflow_runs", out JsonElement runs) ||
                 runs.ValueKind != JsonValueKind.Array)
             {
                 return new GitHubWorkflowData();
@@ -790,8 +818,13 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument branchDoc = await GetJsonAsync(
+            using JsonDocument? branchDoc = await GetJsonAsync(
                 $"{repositoryApiRoot}/branches/{Uri.EscapeDataString(defaultBranch)}");
+
+            if (branchDoc is null)
+            {
+                return new GitHubBranchProtectionData();
+            }
 
             bool? isProtected = branchDoc.RootElement.TryGetProperty("protected", out JsonElement protectedElement) &&
                                 protectedElement.ValueKind is JsonValueKind.True or JsonValueKind.False
@@ -877,10 +910,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument commitsDoc = await GetJsonAsync(
+            using JsonDocument? commitsDoc = await GetJsonAsync(
                 $"{repositoryApiRoot}/commits?sha={Uri.EscapeDataString(defaultBranch)}&since={Uri.EscapeDataString(DateTimeOffset.UtcNow.AddMonths(-12).ToString("O"))}&per_page=100");
 
-            if (commitsDoc.RootElement.ValueKind != JsonValueKind.Array)
+            if (commitsDoc?.RootElement.ValueKind != JsonValueKind.Array)
             {
                 return new GitHubCommitHealthData();
             }
@@ -957,10 +990,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
         try
         {
             string since = Uri.EscapeDataString(DateTimeOffset.UtcNow.AddDays(-90).ToString("O"));
-            using JsonDocument issuesDoc = await GetJsonAsync(
+            using JsonDocument? issuesDoc = await GetJsonAsync(
                 $"{repositoryApiRoot}/issues?state=closed&labels=bug&sort=updated&direction=desc&since={since}&per_page=50");
 
-            if (issuesDoc.RootElement.ValueKind != JsonValueKind.Array)
+            if (issuesDoc?.RootElement.ValueKind != JsonValueKind.Array)
             {
                 return [];
             }
@@ -999,10 +1032,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
             await throttler.WaitAsync();
             try
             {
-                using JsonDocument eventsDoc = await GetJsonAsync(
+                using JsonDocument? eventsDoc = await GetOptionalJsonAsync(
                     $"{repositoryApiRoot}/issues/{issue.Number}/timeline?per_page=100");
 
-                return eventsDoc.RootElement.ValueKind == JsonValueKind.Array &&
+                return eventsDoc?.RootElement.ValueKind == JsonValueKind.Array &&
                        eventsDoc.RootElement.EnumerateArray().Any(eventItem =>
                            string.Equals(
                                eventItem.TryGetProperty("event", out JsonElement eventElement) ? eventElement.GetString() : null,
@@ -1027,10 +1060,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument commitsDoc = await GetJsonAsync(
+            using JsonDocument? commitsDoc = await GetOptionalJsonAsync(
                 $"{repositoryApiRoot}/commits?sha={Uri.EscapeDataString(defaultBranch)}&path={Uri.EscapeDataString(path)}&per_page=1");
 
-            if (commitsDoc.RootElement.ValueKind != JsonValueKind.Array)
+            if (commitsDoc?.RootElement.ValueKind != JsonValueKind.Array)
             {
                 return null;
             }
@@ -1052,10 +1085,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument workflowsDoc = await GetJsonAsync(
+            using JsonDocument? workflowsDoc = await GetJsonAsync(
                 $"{repositoryApiRoot}/contents/.github/workflows?ref={Uri.EscapeDataString(defaultBranch)}");
 
-            if (workflowsDoc.RootElement.ValueKind != JsonValueKind.Array)
+            if (workflowsDoc?.RootElement.ValueKind != JsonValueKind.Array)
             {
                 return new GitHubWorkflowFileSignals();
             }
@@ -1134,10 +1167,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument reviewsDoc =
-                await GetJsonAsync($"{repositoryApiRoot}/pulls/{pullRequestNumber}/reviews?per_page=100");
+            using JsonDocument? reviewsDoc =
+                await GetOptionalJsonAsync($"{repositoryApiRoot}/pulls/{pullRequestNumber}/reviews?per_page=100");
 
-            if (reviewsDoc.RootElement.ValueKind != JsonValueKind.Array)
+            if (reviewsDoc?.RootElement.ValueKind != JsonValueKind.Array)
             {
                 return [];
             }
@@ -1164,7 +1197,7 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
         {
             string scorecardUrl = $"https://api.securityscorecards.dev/projects/github.com/{owner}/{repo}";
             logger.LogDebug("GET {Url}", scorecardUrl);
-            using HttpResponseMessage response = await HttpClient.GetAsync(scorecardUrl);
+            using HttpResponseMessage response = await ScorecardHttpClient.GetAsync(scorecardUrl);
             response.EnsureSuccessStatusCode();
 
             using JsonDocument scorecardDoc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
@@ -1212,10 +1245,10 @@ internal sealed class GitHubRepositoryRiskEnricher(ILogger logger, string? gitHu
     {
         try
         {
-            using JsonDocument fileDoc = await GetJsonAsync(
+            using JsonDocument? fileDoc = await GetJsonAsync(
                 $"{repositoryApiRoot}/contents/{Uri.EscapeDataString(path)}?ref={Uri.EscapeDataString(defaultBranch)}");
 
-            if (fileDoc.RootElement.TryGetProperty("content", out JsonElement contentElement))
+            if (fileDoc is not null && fileDoc.RootElement.TryGetProperty("content", out JsonElement contentElement))
             {
                 string? encoded = contentElement.GetString();
                 if (!string.IsNullOrWhiteSpace(encoded))

--- a/Src/PackageGuard.Specs/Common/ScriptedHttpMessageHandler.cs
+++ b/Src/PackageGuard.Specs/Common/ScriptedHttpMessageHandler.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PackageGuard.Specs.Common;
+
+/// <summary>
+/// An <see cref="HttpMessageHandler"/> that answers from a script instead of the network, and records what it was
+/// asked for.
+/// </summary>
+internal sealed class ScriptedHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, int, HttpResponseMessage> respond;
+    private readonly ConcurrentQueue<HttpRequestMessage> requests = new();
+    private int requestCount;
+    private int concurrentRequestCount;
+    private int peakConcurrentRequestCount;
+
+    /// <summary>
+    /// Creates a handler that calls <paramref name="respond"/> for every request, passing the one-based index of the
+    /// request so that a script can answer differently on a retry.
+    /// </summary>
+    public ScriptedHttpMessageHandler(Func<HttpRequestMessage, int, HttpResponseMessage> respond)
+    {
+        this.respond = respond;
+    }
+
+    /// <summary>
+    /// Creates a handler that always answers with <paramref name="response"/>.
+    /// </summary>
+    public static ScriptedHttpMessageHandler AlwaysReturns(Func<HttpResponseMessage> response) =>
+        new((_, _) => response());
+
+    /// <summary>
+    /// The requests received so far, in the order they arrived.
+    /// </summary>
+    public IReadOnlyList<HttpRequestMessage> Requests => requests.ToArray();
+
+    /// <summary>
+    /// The number of requests received so far.
+    /// </summary>
+    public int RequestCount => Volatile.Read(ref requestCount);
+
+    /// <summary>
+    /// The highest number of requests that were in flight at the same time.
+    /// </summary>
+    public int PeakConcurrentRequestCount => Volatile.Read(ref peakConcurrentRequestCount);
+
+    /// <summary>
+    /// The URLs of the requests received so far.
+    /// </summary>
+    public IReadOnlyList<string> RequestedUrls => requests.Select(request => request.RequestUri!.ToString()).ToArray();
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        requests.Enqueue(request);
+        int index = Interlocked.Increment(ref requestCount);
+        TrackPeakConcurrency(Interlocked.Increment(ref concurrentRequestCount));
+
+        try
+        {
+            await Task.Yield();
+            return respond(request, index);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref concurrentRequestCount);
+        }
+    }
+
+    /// <summary>
+    /// Raises the recorded peak whenever the current number of in-flight requests exceeds it.
+    /// </summary>
+    private void TrackPeakConcurrency(int current)
+    {
+        int peak = Volatile.Read(ref peakConcurrentRequestCount);
+        while (current > peak)
+        {
+            int previous = Interlocked.CompareExchange(ref peakConcurrentRequestCount, current, peak);
+            if (previous == peak)
+            {
+                return;
+            }
+
+            peak = previous;
+        }
+    }
+}
+
+/// <summary>
+/// Builds the HTTP responses that <see cref="ScriptedHttpMessageHandler"/> hands out.
+/// </summary>
+internal static class ScriptedResponse
+{
+    /// <summary>
+    /// Builds a successful JSON response, optionally carrying an entity tag.
+    /// </summary>
+    public static HttpResponseMessage Json(string body, string eTag = null)
+    {
+        HttpResponseMessage response = new(HttpStatusCode.OK) { Content = new StringContent(body) };
+        if (eTag is not null)
+        {
+            response.Headers.TryAddWithoutValidation("ETag", eTag);
+        }
+
+        return WithRateLimit(response, remaining: 4000);
+    }
+
+    /// <summary>
+    /// Builds a <c>304 Not Modified</c> response.
+    /// </summary>
+    public static HttpResponseMessage NotModified() =>
+        WithRateLimit(new HttpResponseMessage(HttpStatusCode.NotModified), remaining: 4000);
+
+    /// <summary>
+    /// Builds a <c>404 Not Found</c> response.
+    /// </summary>
+    public static HttpResponseMessage NotFound() =>
+        WithRateLimit(new HttpResponseMessage(HttpStatusCode.NotFound), remaining: 4000);
+
+    /// <summary>
+    /// Builds the <c>403</c> that GitHub sends for a secondary rate limit, asking the caller to retry shortly.
+    /// </summary>
+    public static HttpResponseMessage SecondaryRateLimited(int retryAfterSeconds = 0)
+    {
+        HttpResponseMessage response = new(HttpStatusCode.Forbidden);
+        response.Headers.TryAddWithoutValidation("retry-after", retryAfterSeconds.ToString());
+        return WithRateLimit(response, remaining: 3000);
+    }
+
+    /// <summary>
+    /// Builds the <c>403</c> that GitHub sends when the hourly budget is spent, resetting after the given delay.
+    /// </summary>
+    public static HttpResponseMessage PrimaryRateLimited(TimeSpan resetsIn)
+    {
+        HttpResponseMessage response = new(HttpStatusCode.Forbidden);
+        return WithRateLimit(response, remaining: 0, resetsIn);
+    }
+
+    /// <summary>
+    /// Adds the <c>x-ratelimit-*</c> headers that GitHub reports its budget through.
+    /// </summary>
+    public static HttpResponseMessage WithRateLimit(HttpResponseMessage response, int remaining,
+        TimeSpan? resetsIn = null, int limit = 5000)
+    {
+        DateTimeOffset resetsAt = DateTimeOffset.UtcNow + (resetsIn ?? TimeSpan.FromMinutes(30));
+        response.Headers.Remove("x-ratelimit-limit");
+        response.Headers.Remove("x-ratelimit-remaining");
+        response.Headers.Remove("x-ratelimit-reset");
+        response.Headers.TryAddWithoutValidation("x-ratelimit-limit", limit.ToString());
+        response.Headers.TryAddWithoutValidation("x-ratelimit-remaining", remaining.ToString());
+        response.Headers.TryAddWithoutValidation("x-ratelimit-reset", resetsAt.ToUnixTimeSeconds().ToString());
+        return response;
+    }
+}

--- a/Src/PackageGuard.Specs/GitHub/GitHubApiClientSpecs.cs
+++ b/Src/PackageGuard.Specs/GitHub/GitHubApiClientSpecs.cs
@@ -132,13 +132,21 @@ public class GitHubApiClientSpecs
         var handler = ScriptedHttpMessageHandler.AlwaysReturns(() => ScriptedResponse.Json("{}"));
         using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
 
+        Task<JsonDocument>[] requests = Enumerable.Range(0, 60)
+            .Select(index => client.GetJsonAsync($"https://api.github.com/repos/acme/widget/pulls/{index}"))
+            .ToArray();
+
         // Act
-        await Task.WhenAll(Enumerable.Range(0, 60)
-            .Select(index => client.GetJsonAsync($"https://api.github.com/repos/acme/widget/pulls/{index}")));
+        JsonDocument[] responses = await Task.WhenAll(requests);
 
         // Assert
         handler.RequestCount.Should().Be(60);
         handler.PeakConcurrentRequestCount.Should().BeLessThanOrEqualTo(8);
+
+        foreach (JsonDocument response in responses)
+        {
+            response.Dispose();
+        }
     }
 
     [TestMethod]

--- a/Src/PackageGuard.Specs/GitHub/GitHubApiClientSpecs.cs
+++ b/Src/PackageGuard.Specs/GitHub/GitHubApiClientSpecs.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PackageGuard.Core.GitHub;
+using PackageGuard.Specs.Common;
+
+namespace PackageGuard.Specs.GitHub;
+
+[TestClass]
+public class GitHubApiClientSpecs
+{
+    private const string Url = "https://api.github.com/repos/acme/widget";
+
+    [TestMethod]
+    public async Task Returns_the_parsed_response_of_a_successful_request()
+    {
+        // Arrange
+        var handler = new ScriptedHttpMessageHandler((_, _) => ScriptedResponse.Json("""{"name":"widget"}"""));
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+
+        // Act
+        using JsonDocument document = await client.GetJsonAsync(Url);
+
+        // Assert
+        document!.RootElement.GetProperty("name").GetString().Should().Be("widget");
+    }
+
+    [TestMethod]
+    public async Task Retries_a_request_that_hits_the_secondary_rate_limit()
+    {
+        // Arrange
+        var handler = new ScriptedHttpMessageHandler((_, attempt) => attempt == 1
+            ? ScriptedResponse.SecondaryRateLimited()
+            : ScriptedResponse.Json("""{"name":"widget"}"""));
+
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+
+        // Act
+        using JsonDocument document = await client.GetJsonAsync(Url);
+
+        // Assert
+        document.Should().NotBeNull();
+        handler.RequestCount.Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task Stops_requesting_once_the_budget_is_spent_and_the_reset_is_far_away()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() =>
+            ScriptedResponse.PrimaryRateLimited(TimeSpan.FromMinutes(45)));
+
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+
+        // Act
+        using JsonDocument first = await client.GetJsonAsync(Url);
+        using JsonDocument second = await client.GetJsonAsync("https://api.github.com/repos/acme/gadget");
+
+        // Assert
+        first.Should().BeNull("the budget was spent");
+        second.Should().BeNull("no further requests should be attempted");
+        client.IsExhausted.Should().BeTrue();
+        handler.RequestCount.Should().Be(1, "the second URL should never reach the network");
+    }
+
+    [TestMethod]
+    public async Task Skips_optional_requests_once_the_budget_drops_into_the_reserve()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() =>
+            ScriptedResponse.WithRateLimit(ScriptedResponse.Json("{}"), remaining: 12));
+
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+        await client.GetJsonAsync(Url);
+
+        // Act
+        using JsonDocument optional = await client.GetJsonAsync("https://api.github.com/repos/acme/widget/issues/1/timeline",
+            GitHubRequestImportance.Optional);
+
+        using JsonDocument essential = await client.GetJsonAsync("https://api.github.com/repos/acme/gadget");
+
+        // Assert
+        optional.Should().BeNull("optional signals make way for the packages still to be scanned");
+        essential.Should().NotBeNull("essential requests keep going while the budget allows any request");
+        handler.RequestCount.Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task Replays_the_cached_body_when_the_resource_did_not_change()
+    {
+        // Arrange
+        var handler = new ScriptedHttpMessageHandler((_, attempt) => attempt == 1
+            ? ScriptedResponse.Json("""{"name":"widget"}""", eTag: "\"abc123\"")
+            : ScriptedResponse.NotModified());
+
+        var cache = new GitHubResponseCache(NullLogger.Instance);
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, cache, handler);
+        await client.GetJsonAsync(Url);
+
+        // Act
+        using JsonDocument revalidated = await client.GetJsonAsync(Url);
+
+        // Assert
+        revalidated!.RootElement.GetProperty("name").GetString().Should().Be("widget");
+        handler.Requests.Last().Headers.IfNoneMatch.ToString().Should().Be("\"abc123\"");
+    }
+
+    [TestMethod]
+    public async Task Remembers_that_a_resource_does_not_exist()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(ScriptedResponse.NotFound);
+        var cache = new GitHubResponseCache(NullLogger.Instance);
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, cache, handler);
+
+        // Act
+        await client.GetJsonAsync(Url);
+        await client.GetJsonAsync(Url);
+
+        // Assert
+        handler.RequestCount.Should().Be(1, "a known-missing resource should not be probed again");
+    }
+
+    [TestMethod]
+    public async Task Keeps_the_number_of_concurrent_requests_below_the_secondary_rate_limit()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() => ScriptedResponse.Json("{}"));
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+
+        // Act
+        await Task.WhenAll(Enumerable.Range(0, 60)
+            .Select(index => client.GetJsonAsync($"https://api.github.com/repos/acme/widget/pulls/{index}")));
+
+        // Assert
+        handler.RequestCount.Should().Be(60);
+        handler.PeakConcurrentRequestCount.Should().BeLessThanOrEqualTo(8);
+    }
+
+    [TestMethod]
+    public async Task Sends_the_configured_token_as_a_bearer_credential()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() => ScriptedResponse.Json("{}"));
+        using var client = new GitHubApiClient(NullLogger.Instance, "secret-token", responseCache: null, handler);
+
+        // Act
+        await client.GetJsonAsync(Url);
+
+        // Assert
+        handler.Requests.Single().Headers.Authorization!.ToString().Should().Be("Bearer secret-token");
+    }
+}

--- a/Src/PackageGuard.Specs/GitHub/GitHubLicenseFetcherSpecs.cs
+++ b/Src/PackageGuard.Specs/GitHub/GitHubLicenseFetcherSpecs.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PackageGuard.Core.CSharp.FetchingStrategies;
+using PackageGuard.Core.GitHub;
+using PackageGuard.Core.Package;
+using PackageGuard.Specs.Common;
+
+namespace PackageGuard.Specs.GitHub;
+
+[TestClass]
+public class GitHubLicenseFetcherSpecs
+{
+    private const string LicenseBody = """{"license":{"spdx_id":"MIT"}}""";
+
+    [TestMethod]
+    public async Task Resolves_the_spdx_identifier_of_a_github_repository()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() => ScriptedResponse.Json(LicenseBody));
+        PackageInfo package = CreatePackage();
+
+        // Act
+        await FetchAsync(handler, package);
+
+        // Assert
+        package.License.Should().Be("MIT");
+        package.LicenseEvidence.Should().Be(LicenseEvidence.Concluded);
+    }
+
+    [TestMethod]
+    public async Task Treats_a_repository_without_an_asserted_license_as_unresolved()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() =>
+            ScriptedResponse.Json("""{"license":{"spdx_id":"NOASSERTION"}}"""));
+
+        PackageInfo package = CreatePackage();
+
+        // Act
+        await FetchAsync(handler, package);
+
+        // Assert
+        package.License.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task Retries_a_license_lookup_that_hits_the_secondary_rate_limit()
+    {
+        // Arrange
+        var handler = new ScriptedHttpMessageHandler((_, attempt) => attempt == 1
+            ? ScriptedResponse.SecondaryRateLimited()
+            : ScriptedResponse.Json(LicenseBody));
+
+        PackageInfo package = CreatePackage();
+
+        // Act
+        await FetchAsync(handler, package);
+
+        // Assert
+        package.License.Should().Be("MIT", "the retry succeeded");
+        handler.RequestCount.Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task Leaves_the_license_unresolved_once_the_rate_limit_budget_is_spent()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() =>
+            ScriptedResponse.PrimaryRateLimited(TimeSpan.FromMinutes(45)));
+
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+        var fetcher = new GitHubLicenseFetcher(NullLogger.Instance, client);
+
+        // Act
+        await fetcher.FetchLicenseAsync(CreatePackage());
+        await fetcher.FetchLicenseAsync(CreatePackage("Contoso.Gadget", "https://github.com/contoso/gadget"));
+
+        // Assert
+        handler.RequestCount.Should().Be(1, "the second package should not be attempted at all");
+    }
+
+    [TestMethod]
+    public async Task Ignores_a_package_whose_repository_is_not_on_github()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() => ScriptedResponse.Json(LicenseBody));
+        PackageInfo package = CreatePackage("Acme.Widget", "https://gitlab.com/acme/widget");
+
+        // Act
+        await FetchAsync(handler, package);
+
+        // Assert
+        package.License.Should().BeNull();
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task Asks_the_license_endpoint_of_the_repository_named_by_the_package()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() => ScriptedResponse.Json(LicenseBody));
+
+        // Act
+        await FetchAsync(handler, CreatePackage());
+
+        // Assert
+        handler.RequestedUrls.Single().Should().Be("https://api.github.com/repos/acme/widget/license");
+    }
+
+    private static async Task FetchAsync(ScriptedHttpMessageHandler handler, PackageInfo package)
+    {
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+        var fetcher = new GitHubLicenseFetcher(NullLogger.Instance, client);
+        await fetcher.FetchLicenseAsync(package);
+    }
+
+    private static PackageInfo CreatePackage(string name = "Acme.Widget",
+        string repositoryUrl = "https://github.com/acme/widget") =>
+        new()
+        {
+            Name = name,
+            Version = "1.0.0",
+            Source = "NuGet",
+            RepositoryUrl = repositoryUrl
+        };
+}

--- a/Src/PackageGuard.Specs/GitHub/GitHubRepositoryRiskEnricherCachingSpecs.cs
+++ b/Src/PackageGuard.Specs/GitHub/GitHubRepositoryRiskEnricherCachingSpecs.cs
@@ -51,7 +51,7 @@ public class GitHubRepositoryRiskEnricherCachingSpecs
         var enricher = new GitHubRepositoryRiskEnricher(NullLogger.Instance, client);
 
         // Act
-        await enricher.EnrichAsync(CreatePackage("Acme.Widget.Core", "https://github.com/acme/widget"));
+        await enricher.EnrichAsync(CreatePackage("Acme.Widget.Core"));
         await enricher.EnrichAsync(CreatePackage("Contoso.Gadget", "https://github.com/contoso/gadget"));
 
         // Assert

--- a/Src/PackageGuard.Specs/GitHub/GitHubRepositoryRiskEnricherCachingSpecs.cs
+++ b/Src/PackageGuard.Specs/GitHub/GitHubRepositoryRiskEnricherCachingSpecs.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PackageGuard.Core.GitHub;
+using PackageGuard.Core.Package;
+using PackageGuard.Core.Risk.Enrichment;
+using PackageGuard.Specs.Common;
+
+namespace PackageGuard.Specs.GitHub;
+
+[TestClass]
+[DoNotParallelize]
+public class GitHubRepositoryRiskEnricherCachingSpecs
+{
+    [TestInitialize]
+    public void ClearSharedState() => GitHubRepositoryRiskEnricher.ClearCache();
+
+    [TestCleanup]
+    public void ClearSharedStateAfterwards() => GitHubRepositoryRiskEnricher.ClearCache();
+
+    [TestMethod]
+    public async Task Does_not_repeat_a_failed_repository_lookup_for_every_package_of_that_repository()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() =>
+            ScriptedResponse.WithRateLimit(ScriptedResponse.NotFound(), remaining: 4000));
+
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+        var enricher = new GitHubRepositoryRiskEnricher(NullLogger.Instance, client);
+
+        // Act
+        await enricher.EnrichAsync(CreatePackage("Acme.Widget.Core"));
+        await enricher.EnrichAsync(CreatePackage("Acme.Widget.Abstractions"));
+        await enricher.EnrichAsync(CreatePackage("Acme.Widget.Extensions"));
+
+        // Assert
+        handler.RequestCount.Should().Be(1,
+            "the repository is only looked up once, however many packages point at it");
+    }
+
+    [TestMethod]
+    public async Task Stops_looking_up_repositories_once_the_rate_limit_budget_is_spent()
+    {
+        // Arrange
+        var handler = ScriptedHttpMessageHandler.AlwaysReturns(() =>
+            ScriptedResponse.PrimaryRateLimited(TimeSpan.FromMinutes(45)));
+
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+        var enricher = new GitHubRepositoryRiskEnricher(NullLogger.Instance, client);
+
+        // Act
+        await enricher.EnrichAsync(CreatePackage("Acme.Widget.Core", "https://github.com/acme/widget"));
+        await enricher.EnrichAsync(CreatePackage("Contoso.Gadget", "https://github.com/contoso/gadget"));
+
+        // Assert
+        handler.RequestCount.Should().Be(1, "the second repository should not be attempted at all");
+    }
+
+    private static PackageInfo CreatePackage(string name, string repositoryUrl = "https://github.com/acme/widget") =>
+        new()
+        {
+            Name = name,
+            Version = "1.0.0",
+            Source = "NuGet",
+            RepositoryUrl = repositoryUrl
+        };
+}


### PR DESCRIPTION
First of four changes that cut the number of network calls PackageGuard makes and stop it from running into GitHub's rate limits.

## What was wrong

PackageGuard talked to `api.github.com` from two places — license resolution and risk enrichment — each with its own `HttpClient`, and neither aware of the rate limit.

Risk enrichment ran six packages at a time, and every package fanned out into per-issue and per-pull-request calls behind their own semaphores, so well over a hundred requests could be in flight at once. GitHub answers that with `403` under its [secondary rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits), which the code then reported as a plain failure to fetch metadata. Grepping the repository for `429`, `Retry-After`, or `x-ratelimit` returned nothing, so a rate-limited run silently produced a risk report full of missing signals.

A repository whose metadata could not be read was also left out of the cache, so all forty packages sharing a repository each retried the same failing fan-out.

## What changed

Every GitHub request now goes through one `GitHubApiClient` that:

- caps concurrency at 8 requests, far below the 100 GitHub allows;
- honours `retry-after` and `x-ratelimit-reset`, retrying short throttles;
- stops making requests once the budget is spent, and says so once with a message naming the reset time and how to raise the limit, rather than spending the rest of the run collecting rejections;
- skips requests marked optional when the budget drops into a reserve, so the packages still to be scanned keep getting their essential signals;
- revalidates responses with `If-None-Match` against a cache stored next to `cache.bin`, and remembers which resources do not exist.

Failed repository lookups are cached as such, which removes the retry storm.

## A note on conditional requests

GitHub documents that a `304 Not Modified` does not count against the primary rate limit. Probing this unauthenticated, `x-ratelimit-used` still incremented on each `304`, so the exemption appears to apply to authenticated callers only. The bandwidth saving holds either way; the rate-limit saving is worth confirming with a token before relying on it.

## Testing

Nine new unit tests drive the client through a scripted `HttpMessageHandler` — no live traffic. They cover the retry, the circuit breaker, the optional-request reserve, conditional requests across runs, negative caching, the concurrency cap, and the amplification fix. Existing suite stays green (207 tests), public API surface unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)