### PR TITLE
Make the risk cache expire, refresh, and be keyed by repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,16 @@ If the limit does run out, PackageGuard reports a warning like
 
   `The GitHub API rate limit is exhausted and resets in 42 minutes.`
 
-and finishes the analysis without the GitHub-based signals, instead of failing. Run it again after the reset to fill in what was left out. Combine this with `--use-caching` so that the work already done is not repeated: alongside the package cache, PackageGuard stores the GitHub responses it received under `.packageguard\github-responses.bin` and revalidates them with conditional requests, which GitHub does not charge against the rate limit of an authenticated caller.
+and finishes the analysis without the GitHub-based signals, instead of failing. Run it again after the reset to fill in what was left out.
+
+Combine this with `--use-caching` so that the work already done is not repeated. Alongside the package cache, PackageGuard writes two more files:
+
+| File | Holds |
+|------|-------|
+| `.packageguard\github-responses.bin` | the GitHub responses received, with their entity tags. Later runs revalidate them with conditional requests, which GitHub does not charge against the rate limit of an authenticated caller. |
+| `.packageguard\github-repositories.bin` | the risk profile of each repository, keyed by repository rather than by package. Dozens of packages can share one repository, and its profile is collected once. |
+
+Both are refreshed on the schedule set by `--risk-cache-max-age` (24 hours by default), and `--refresh-risk-cache` collects everything again regardless. Commit them alongside `cache.bin` if you want CI runs to benefit as well.
 
 ## Roadmap
 

--- a/Src/PackageGuard.Core/GitHub/GitHubApi.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubApi.cs
@@ -24,6 +24,11 @@ internal static class GitHubApi
     private static GitHubResponseCache? responseCache;
 
     /// <summary>
+    /// The repository profile cache shared by every risk enricher.
+    /// </summary>
+    private static GitHubRepositoryRiskCache? repositoryCache;
+
+    /// <summary>
     /// Guards the shared client and cache instances.
     /// </summary>
     private static readonly Lock SharedLock = new();
@@ -50,25 +55,44 @@ internal static class GitHubApi
     }
 
     /// <summary>
-    /// Loads previously cached GitHub responses that sit next to the package cache at <paramref name="cacheFilePath"/>.
+    /// Returns the repository profile cache, creating it on first use.
     /// </summary>
     /// <param name="logger">The logger to report cache problems to.</param>
-    /// <param name="cacheFilePath">The path of the package cache file the response cache sits next to.</param>
-    public static async Task LoadResponseCacheAsync(ILogger logger, string cacheFilePath)
+    public static GitHubRepositoryRiskCache GetOrCreateRepositoryCache(ILogger logger)
     {
-        GitHubResponseCache cache = GetOrCreateResponseCache(logger);
-        await cache.LoadAsync(GetResponseCacheFilePath(cacheFilePath));
+        lock (SharedLock)
+        {
+            return repositoryCache ??= new GitHubRepositoryRiskCache(logger);
+        }
     }
 
     /// <summary>
-    /// Persists the GitHub responses seen during this run next to the package cache at <paramref name="cacheFilePath"/>.
+    /// Loads the responses and repository profiles cached next to the package cache at
+    /// <paramref name="cacheFilePath"/>.
     /// </summary>
     /// <param name="logger">The logger to report cache problems to.</param>
-    /// <param name="cacheFilePath">The path of the package cache file the response cache sits next to.</param>
-    public static async Task SaveResponseCacheAsync(ILogger logger, string cacheFilePath)
+    /// <param name="cacheFilePath">The path of the package cache file the caches sit next to.</param>
+    /// <param name="settings">The settings that decide how long a cached profile is reused.</param>
+    public static async Task LoadCachesAsync(ILogger logger, string cacheFilePath, AnalyzerSettings settings)
     {
-        GitHubResponseCache cache = GetOrCreateResponseCache(logger);
-        await cache.SaveAsync(GetResponseCacheFilePath(cacheFilePath));
+        GitHubRepositoryRiskCache profiles = GetOrCreateRepositoryCache(logger);
+        profiles.MaxAge = settings.RiskCacheMaxAge;
+        profiles.IsRefreshForced = settings.RefreshRiskCache;
+
+        await GetOrCreateResponseCache(logger).LoadAsync(GetResponseCacheFilePath(cacheFilePath));
+        await profiles.LoadAsync(cacheFilePath);
+    }
+
+    /// <summary>
+    /// Persists the responses and repository profiles seen during this run next to the package cache at
+    /// <paramref name="cacheFilePath"/>.
+    /// </summary>
+    /// <param name="logger">The logger to report cache problems to.</param>
+    /// <param name="cacheFilePath">The path of the package cache file the caches sit next to.</param>
+    public static async Task SaveCachesAsync(ILogger logger, string cacheFilePath)
+    {
+        await GetOrCreateResponseCache(logger).SaveAsync(GetResponseCacheFilePath(cacheFilePath));
+        await GetOrCreateRepositoryCache(logger).SaveAsync(cacheFilePath);
     }
 
     /// <summary>

--- a/Src/PackageGuard.Core/GitHub/GitHubRepositoryRiskCache.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubRepositoryRiskCache.cs
@@ -1,0 +1,208 @@
+using System.IO.Compression;
+using MemoryPack;
+using Microsoft.Extensions.Logging;
+using Pathy;
+
+namespace PackageGuard.Core.GitHub;
+
+/// <summary>
+/// Caches the assembled risk profile of a repository, keyed by the repository itself rather than by the packages that
+/// come out of it.
+/// </summary>
+/// <remarks>
+/// Dozens of packages can share one repository, and its profile is the same for all of them. Keying the cache by
+/// repository means a repository is described once per run, one package going stale cannot force the whole profile to
+/// be collected again, and the profile survives to the next run.
+/// </remarks>
+internal sealed class GitHubRepositoryRiskCache(ILogger logger)
+{
+    /// <summary>
+    /// The cached profiles, keyed by the repository's API root URL.
+    /// </summary>
+    private readonly Dictionary<string, GitHubRepositoryRiskCacheEntry> entries =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Guards access to <see cref="entries"/>.
+    /// </summary>
+    private readonly Lock entriesLock = new();
+
+    /// <summary>
+    /// How long a cached profile is reused before it is collected again.
+    /// </summary>
+    public TimeSpan MaxAge { get; set; } = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// Ignores what is on disk and collects every profile again.
+    /// </summary>
+    public bool IsRefreshForced { get; set; }
+
+    /// <summary>
+    /// Returns the cached profile for <paramref name="repositoryApiRoot"/> when it is still fresh enough to reuse.
+    /// A cached <see langword="null"/> records a repository that could not be read, so that the packages behind it do
+    /// not each retry the same failing lookup.
+    /// </summary>
+    /// <param name="repositoryApiRoot">The API root URL of the repository.</param>
+    /// <param name="data">The cached profile, which is <see langword="null"/> for a repository that could not be read.</param>
+    /// <returns><see langword="true"/> when the cache can answer for this repository.</returns>
+    public bool TryGet(string repositoryApiRoot, out GitHubRepositoryRiskData? data)
+    {
+        data = null;
+
+        lock (entriesLock)
+        {
+            if (!entries.TryGetValue(repositoryApiRoot, out GitHubRepositoryRiskCacheEntry? entry) || IsStale(entry))
+            {
+                return false;
+            }
+
+            entry.IsUsed = true;
+            data = entry.Data;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Stores the profile of a repository, or a <see langword="null"/> profile for one that could not be read.
+    /// </summary>
+    /// <param name="repositoryApiRoot">The API root URL of the repository.</param>
+    /// <param name="data">The profile to cache, or <see langword="null"/> when it could not be collected.</param>
+    public void Store(string repositoryApiRoot, GitHubRepositoryRiskData? data)
+    {
+        lock (entriesLock)
+        {
+            entries[repositoryApiRoot] = new GitHubRepositoryRiskCacheEntry
+            {
+                RepositoryApiRoot = repositoryApiRoot,
+                Data = data,
+                StoredAt = DateTimeOffset.UtcNow,
+                IsUsed = true
+            };
+        }
+    }
+
+    /// <summary>
+    /// Loads the profiles persisted next to the package cache at <paramref name="cacheFilePath"/>.
+    /// </summary>
+    /// <param name="cacheFilePath">The path of the package cache file this cache sits next to.</param>
+    public async Task LoadAsync(string cacheFilePath)
+    {
+        string path = GetFilePath(cacheFilePath);
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            GitHubRepositoryRiskCacheEntry[] loaded = await ReadEntriesAsync(path);
+            Merge(loaded);
+            logger.LogDebug("Loaded {Count} cached GitHub repository profiles from {Path}", loaded.Length, path);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Could not load the GitHub repository profile cache from {Path}", path);
+        }
+    }
+
+    /// <summary>
+    /// Persists the profiles that were used during this run, next to the package cache at
+    /// <paramref name="cacheFilePath"/>.
+    /// </summary>
+    /// <param name="cacheFilePath">The path of the package cache file this cache sits next to.</param>
+    public async Task SaveAsync(string cacheFilePath)
+    {
+        string path = GetFilePath(cacheFilePath);
+        GitHubRepositoryRiskCacheEntry[] used = TakeEntriesWorthKeeping();
+
+        try
+        {
+            path.ToPath().Directory.CreateDirectoryRecursively();
+            await WriteEntriesAsync(path, used);
+            logger.LogDebug("Persisted {Count} GitHub repository profiles to {Path}", used.Length, path);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Could not persist the GitHub repository profile cache to {Path}", path);
+        }
+    }
+
+    /// <summary>
+    /// Discards every cached profile. Only used by the tests.
+    /// </summary>
+    internal void Clear()
+    {
+        lock (entriesLock)
+        {
+            entries.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Returns the entries worth keeping: the ones collected or reused during this run, and the ones that are still
+    /// within their maximum age.
+    /// </summary>
+    /// <remarks>
+    /// A run where every package was already up to date touches no profile at all. Keeping only what this run touched
+    /// would empty the cache on such a run and undo the point of having it.
+    /// </remarks>
+    private GitHubRepositoryRiskCacheEntry[] TakeEntriesWorthKeeping()
+    {
+        lock (entriesLock)
+        {
+            return entries.Values.Where(entry => entry.IsUsed || IsWithinMaxAge(entry)).ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when an entry has not yet reached its maximum age, regardless of whether a
+    /// refresh was asked for.
+    /// </summary>
+    private bool IsWithinMaxAge(GitHubRepositoryRiskCacheEntry entry) =>
+        DateTimeOffset.UtcNow - entry.StoredAt <= MaxAge;
+
+    /// <summary>
+    /// Adds the loaded entries, keeping any entry already collected during this run.
+    /// </summary>
+    private void Merge(GitHubRepositoryRiskCacheEntry[] loaded)
+    {
+        lock (entriesLock)
+        {
+            foreach (GitHubRepositoryRiskCacheEntry entry in loaded)
+            {
+                entries.TryAdd(entry.RepositoryApiRoot, entry);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when an entry is too old to reuse, or when a refresh was asked for.
+    /// </summary>
+    private bool IsStale(GitHubRepositoryRiskCacheEntry entry) => IsRefreshForced || !IsWithinMaxAge(entry);
+
+    /// <summary>
+    /// Reads and decompresses the persisted entries.
+    /// </summary>
+    private static async Task<GitHubRepositoryRiskCacheEntry[]> ReadEntriesAsync(string path)
+    {
+        await using FileStream fileStream = new(path, FileMode.Open, FileAccess.Read);
+        await using BrotliStream decompressor = new(fileStream, CompressionMode.Decompress);
+        return await MemoryPackSerializer.DeserializeAsync<GitHubRepositoryRiskCacheEntry[]>(decompressor) ?? [];
+    }
+
+    /// <summary>
+    /// Compresses and writes the given entries.
+    /// </summary>
+    private static async Task WriteEntriesAsync(string path, GitHubRepositoryRiskCacheEntry[] entries)
+    {
+        await using FileStream fileStream = new(path, FileMode.Create, FileAccess.Write);
+        await using BrotliStream compressor = new(fileStream, CompressionLevel.Fastest);
+        await MemoryPackSerializer.SerializeAsync(compressor, entries);
+    }
+
+    /// <summary>
+    /// Derives the cache file path from the path of the package cache file.
+    /// </summary>
+    private static string GetFilePath(string cacheFilePath) =>
+        cacheFilePath.ToPath().Directory / "github-repositories.bin";
+}

--- a/Src/PackageGuard.Core/GitHub/GitHubRepositoryRiskCacheEntry.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubRepositoryRiskCacheEntry.cs
@@ -1,0 +1,32 @@
+using MemoryPack;
+
+namespace PackageGuard.Core.GitHub;
+
+/// <summary>
+/// One repository's cached risk profile, together with when it was collected.
+/// </summary>
+[MemoryPackable]
+internal sealed partial class GitHubRepositoryRiskCacheEntry
+{
+    /// <summary>
+    /// The API root URL of the repository the profile describes.
+    /// </summary>
+    public required string RepositoryApiRoot { get; init; }
+
+    /// <summary>
+    /// The collected profile, or <see langword="null"/> when the repository could not be read.
+    /// </summary>
+    public GitHubRepositoryRiskData? Data { get; init; }
+
+    /// <summary>
+    /// The moment the profile was collected.
+    /// </summary>
+    public DateTimeOffset StoredAt { get; init; }
+
+    /// <summary>
+    /// Indicates whether the entry was read or written during the current run. Entries left untouched are dropped
+    /// when the cache is persisted, so it does not keep repositories that are no longer referenced.
+    /// </summary>
+    [MemoryPackIgnore]
+    public bool IsUsed { get; set; }
+}

--- a/Src/PackageGuard.Core/GitHub/GitHubRepositoryRiskData.cs
+++ b/Src/PackageGuard.Core/GitHub/GitHubRepositoryRiskData.cs
@@ -1,0 +1,170 @@
+using MemoryPack;
+
+namespace PackageGuard.Core.GitHub;
+
+/// <summary>Aggregated repository risk metrics for a GitHub repository.</summary>
+[MemoryPackable]
+internal sealed partial class GitHubRepositoryRiskData
+{
+    /// <summary>The canonical HTML URL of the repository as returned by the GitHub API.</summary>
+    public string CanonicalUrl { get; init; } = string.Empty;
+
+    /// <summary>Indicates whether the repository owner is an organization.</summary>
+    public bool OwnerIsOrganization { get; init; }
+
+    /// <summary>The date the repository owner account was created.</summary>
+    public DateTimeOffset? OwnerCreatedAt { get; init; }
+
+    /// <summary>The total number of non-bot contributors.</summary>
+    public int ContributorCount { get; init; }
+
+    /// <summary>The fraction of total contributions made by the top contributor.</summary>
+    public double? TopContributorShare { get; init; }
+
+    /// <summary>The fraction of total contributions made by the top two contributors combined.</summary>
+    public double? TopTwoContributorShare { get; init; }
+
+    /// <summary>The number of maintainers with commit activity in the last six months.</summary>
+    public int? RecentMaintainerCount { get; init; }
+
+    /// <summary>Indicates whether the repository has a README file.</summary>
+    public bool HasReadme { get; init; }
+
+    /// <summary>Indicates whether the README appears to be a boilerplate default.</summary>
+    public bool HasDefaultReadme { get; init; }
+
+    /// <summary>The date of the most recent commit that touched the README file.</summary>
+    public DateTimeOffset? ReadmeUpdatedAt { get; init; }
+
+    /// <summary>Indicates whether the repository has a CONTRIBUTING.md file.</summary>
+    public bool HasContributingGuide { get; init; }
+
+    /// <summary>Indicates whether the repository has a SECURITY.md file.</summary>
+    public bool HasSecurityPolicy { get; init; }
+
+    /// <summary>Indicates whether the security policy contains detailed contact and reporting information.</summary>
+    public bool? HasDetailedSecurityPolicy { get; init; }
+
+    /// <summary>Indicates whether the security policy describes a coordinated disclosure process.</summary>
+    public bool? HasCoordinatedDisclosure { get; init; }
+
+    /// <summary>Indicates whether the repository has a CHANGELOG file.</summary>
+    public bool HasChangelog { get; init; }
+
+    /// <summary>Indicates whether the CHANGELOG appears to be a boilerplate default.</summary>
+    public bool HasDefaultChangelog { get; init; }
+
+    /// <summary>The date of the most recent commit that touched the CHANGELOG file.</summary>
+    public DateTimeOffset? ChangelogUpdatedAt { get; init; }
+
+    /// <summary>The number of currently open bug issues.</summary>
+    public int OpenBugIssueCount { get; init; }
+
+    /// <summary>The number of critical bug issues that have been open for more than six months.</summary>
+    public int StaleCriticalBugIssueCount { get; init; }
+
+    /// <summary>The median number of days until a maintainer first responds to an open bug issue.</summary>
+    public double? MedianIssueResponseDays { get; init; }
+
+    /// <summary>The median number of days until a maintainer first responds to a critical open bug issue.</summary>
+    public double? MedianCriticalIssueResponseDays { get; init; }
+
+    /// <summary>The fraction of open bug issues that have received at least one maintainer response.</summary>
+    public double? IssueResponseCoverage { get; init; }
+
+    /// <summary>The median age in days of currently open bug issues.</summary>
+    public double? MedianOpenBugAgeDays { get; init; }
+
+    /// <summary>The number of bug issues closed in the last 90 days.</summary>
+    public int? ClosedBugIssueCountLast90Days { get; init; }
+
+    /// <summary>The number of bug issues that were reopened after being closed in the last 90 days.</summary>
+    public int? ReopenedBugIssueCountLast90Days { get; init; }
+
+    /// <summary>The fraction of open bug issues that received a maintainer response within seven days.</summary>
+    public double? IssueTriageWithinSevenDaysRate { get; init; }
+
+    /// <summary>The median number of days from pull request creation to merge.</summary>
+    public double? MedianPullRequestMergeDays { get; init; }
+
+    /// <summary>The fraction of recently merged pull requests authored by external contributors.</summary>
+    public double? ExternalContributionRate { get; init; }
+
+    /// <summary>The number of unique reviewers across recently merged pull requests.</summary>
+    public int? UniqueReviewerCount { get; init; }
+
+    /// <summary>The ratio of unique reviewers to total recently merged pull requests.</summary>
+    public double? ReviewerDiversityRatio { get; init; }
+
+    /// <summary>The number of failed workflow runs among the most recent runs on the default branch.</summary>
+    public int? RecentFailedWorkflowCount { get; init; }
+
+    /// <summary>Indicates whether there is at least one recent successful workflow run on the default branch.</summary>
+    public bool? HasRecentSuccessfulWorkflowRun { get; init; }
+
+    /// <summary>The fraction of completed workflow runs that failed.</summary>
+    public double? WorkflowFailureRate { get; init; }
+
+    /// <summary>Indicates whether the workflow runs show a flaky pattern (intermittent failures and successes).</summary>
+    public bool? HasFlakyWorkflowPattern { get; init; }
+
+    /// <summary>The number of required status checks configured on the default branch.</summary>
+    public int? RequiredStatusCheckCount { get; init; }
+
+    /// <summary>The number of distinct operating system platforms targeted by workflow files.</summary>
+    public int? WorkflowPlatformCount { get; init; }
+
+    /// <summary>Indicates whether workflow files contain a coverage reporting signal.</summary>
+    public bool? HasCoverageWorkflowSignal { get; init; }
+
+    /// <summary>Indicates whether workflow files or Scorecard results suggest reproducible builds.</summary>
+    public bool? HasReproducibleBuildSignal { get; init; }
+
+    /// <summary>Indicates whether the repository uses automated dependency update tooling.</summary>
+    public bool? HasDependencyUpdateAutomation { get; init; }
+
+    /// <summary>Indicates whether workflow files contain a test execution signal.</summary>
+    public bool? HasTestSignal { get; init; }
+
+    /// <summary>The OpenSSF Scorecard aggregate score for the repository.</summary>
+    public double? OpenSsfScore { get; init; }
+
+    /// <summary>Indicates whether the default branch has branch protection enabled.</summary>
+    public bool? HasBranchProtection { get; init; }
+
+    /// <summary>Indicates whether workflow files contain a provenance attestation signal.</summary>
+    public bool? HasProvenanceAttestation { get; init; }
+
+    /// <summary>Indicates whether the most recent release has a verified signature.</summary>
+    public bool? HasVerifiedReleaseSignature { get; init; }
+
+    /// <summary>Indicates whether the repository owner is an organization, used as a proxy for a verified publisher.</summary>
+    public bool? HasVerifiedPublisher { get; init; }
+
+    /// <summary>Indicates whether releases include substantive release notes.</summary>
+    public bool? HasReleaseNotes { get; init; }
+
+    /// <summary>Indicates whether all releases use SemVer-compatible tags.</summary>
+    public bool? HasSemVerReleaseTags { get; init; }
+
+    /// <summary>The mean number of days between consecutive releases.</summary>
+    public double? MeanReleaseIntervalDays { get; init; }
+
+    /// <summary>The fraction of consecutive release transitions that were major-version bumps.</summary>
+    public double? MajorReleaseRatio { get; init; }
+
+    /// <summary>The fraction of releases marked as pre-releases.</summary>
+    public double? PrereleaseRatio { get; init; }
+
+    /// <summary>The number of release pairs published within three days of each other, indicating rapid corrections.</summary>
+    public int? RapidReleaseCorrectionCount { get; init; }
+
+    /// <summary>The fraction of sampled commits that have a verified signature.</summary>
+    public double? VerifiedCommitRatio { get; init; }
+
+    /// <summary>The median number of days since the last commit activity for each active maintainer.</summary>
+    public double? MedianMaintainerActivityDays { get; init; }
+
+    /// <summary>The publication date of the most recent release.</summary>
+    public DateTimeOffset? LastReleaseAt { get; init; }
+}

--- a/Src/PackageGuard.Core/Package/PackageInfo.cs
+++ b/Src/PackageGuard.Core/Package/PackageInfo.cs
@@ -706,4 +706,50 @@ public partial class PackageInfo
     {
         IsUsed = true;
     }
+
+    /// <summary>
+    /// Clears everything that was read from a registry or from a repository, so that a stale cache entry is refilled
+    /// from upstream rather than reused.
+    /// </summary>
+    /// <remarks>
+    /// The entry itself is kept, because it also carries which projects reference the package. Only the values that
+    /// go out of date are dropped: a package version never changes, but the latest version it lags behind, its
+    /// download count, its deprecation status, and every repository and vulnerability signal do.
+    /// </remarks>
+    internal void InvalidateCachedMetadata()
+    {
+        ClearRegistryMetadata();
+        ClearRiskData();
+        CacheUpdatedAt = null;
+    }
+
+    /// <summary>
+    /// Clears the values read from the NuGet or NPM registry.
+    /// </summary>
+    private void ClearRegistryMetadata()
+    {
+        License = null;
+        LicenseEvidence = LicenseEvidence.Unknown;
+        LicenseUrl = null;
+        RepositoryUrl = null;
+        IsDeprecated = null;
+        PublishedAt = null;
+        DownloadCount = null;
+        LatestStableVersion = null;
+        LatestStablePublishedAt = null;
+        VersionUpdateLagDays = null;
+        IsMajorVersionBehindLatest = false;
+        IsMinorVersionBehindLatest = false;
+    }
+
+    /// <summary>
+    /// Marks every risk signal as missing, which makes the enrichers collect it again.
+    /// </summary>
+    private void ClearRiskData()
+    {
+        HasGitHubRiskData = false;
+        HasOsvRiskData = false;
+        HasSigningRiskData = false;
+        HasValidatedLicenseUrl = false;
+    }
 }

--- a/Src/PackageGuard.Core/Package/PackageInfoCollection.cs
+++ b/Src/PackageGuard.Core/Package/PackageInfoCollection.cs
@@ -148,17 +148,20 @@ public class PackageInfoCollection(ILogger logger, AnalyzerSettings? settings = 
     }
 
     /// <summary>
-    /// Sets <see cref="PackageInfo.CacheUpdatedAt"/> to the current UTC time on every entry before serialisation.
+    /// Records when each entry was last confirmed against its upstream sources.
     /// </summary>
+    /// <remarks>
+    /// Entries that were reused from the cache keep the moment they were last refreshed, so that they still expire on
+    /// schedule. Entries that were refreshed this run, and entries that have never been stamped, are stamped now.
+    /// Leaving a refreshed entry with its original timestamp would keep it permanently expired, which made every run
+    /// after the first refetch everything and yet never actually refresh the risk signals.
+    /// </remarks>
     private static void StampCacheEntries(IEnumerable<PackageInfo> packages)
     {
         DateTimeOffset cacheUpdatedAt = DateTimeOffset.UtcNow;
-        foreach (PackageInfo package in packages)
+        foreach (PackageInfo package in packages.Where(package => package.CacheUpdatedAt is null))
         {
-            if (package.CacheUpdatedAt == default)
-            {
-                package.CacheUpdatedAt = cacheUpdatedAt;
-            }
+            package.CacheUpdatedAt = cacheUpdatedAt;
         }
     }
 
@@ -211,14 +214,20 @@ public class PackageInfoCollection(ILogger logger, AnalyzerSettings? settings = 
     /// </summary>
     private PackageInfo? FindCachedPackage(string name, string version, string[] sourceUrls)
     {
-        PackageInfo? package =
-            cache.Values.FirstOrDefault(p => MatchesPackage(p, name, version, sourceUrls) && ShouldReuseCachedPackage(p));
-
-        if (package is not null)
+        PackageInfo? package = cache.Values.FirstOrDefault(p => MatchesPackage(p, name, version, sourceUrls));
+        if (package is null)
         {
-            packages[package.GetCollectionKey()] = package;
+            return null;
         }
 
+        if (!ShouldReuseCachedPackage(package))
+        {
+            logger.LogDebug("Cached metadata for {Name} {Version} is stale and will be refreshed", name, version);
+            package.InvalidateCachedMetadata();
+            return null;
+        }
+
+        packages[package.GetCollectionKey()] = package;
         return package;
     }
 
@@ -267,8 +276,8 @@ public class PackageInfoCollection(ILogger logger, AnalyzerSettings? settings = 
     }
 
     /// <summary>
-    /// Copies missing metadata fields (source, source URL, repository URL, license, license URL)
-    /// from <paramref name="source"/> into <paramref name="target"/> without overwriting existing values.
+    /// Copies the metadata that <paramref name="target"/> is missing from <paramref name="source"/>, without
+    /// overwriting the values it already has.
     /// </summary>
     private static void MergePackageMetadata(PackageInfo target, PackageInfo source)
     {
@@ -282,7 +291,15 @@ public class PackageInfoCollection(ILogger logger, AnalyzerSettings? settings = 
             target.SourceUrl = source.SourceUrl;
         }
 
-        target.RepositoryUrl ??= source.RepositoryUrl;
+        MergeLicense(target, source);
+        MergeVersionMetadata(target, source);
+    }
+
+    /// <summary>
+    /// Copies the license of <paramref name="source"/> when <paramref name="target"/> has none.
+    /// </summary>
+    private static void MergeLicense(PackageInfo target, PackageInfo source)
+    {
         if (target.License is null && source.License is not null)
         {
             target.License = source.License;
@@ -290,6 +307,23 @@ public class PackageInfoCollection(ILogger logger, AnalyzerSettings? settings = 
         }
 
         target.LicenseUrl ??= source.LicenseUrl;
+    }
+
+    /// <summary>
+    /// Copies the registry metadata that goes out of date, so that a refreshed entry picks up the values that were
+    /// just fetched rather than keeping the ones it was invalidated for.
+    /// </summary>
+    private static void MergeVersionMetadata(PackageInfo target, PackageInfo source)
+    {
+        target.RepositoryUrl ??= source.RepositoryUrl;
+        target.IsDeprecated ??= source.IsDeprecated;
+        target.PublishedAt ??= source.PublishedAt;
+        target.DownloadCount ??= source.DownloadCount;
+        target.LatestStableVersion ??= source.LatestStableVersion;
+        target.LatestStablePublishedAt ??= source.LatestStablePublishedAt;
+        target.VersionUpdateLagDays ??= source.VersionUpdateLagDays;
+        target.IsMajorVersionBehindLatest |= source.IsMajorVersionBehindLatest;
+        target.IsMinorVersionBehindLatest |= source.IsMinorVersionBehindLatest;
     }
 
     /// <summary>

--- a/Src/PackageGuard.Core/ProjectAnalyzer.cs
+++ b/Src/PackageGuard.Core/ProjectAnalyzer.cs
@@ -52,7 +52,7 @@ public class ProjectAnalyzer(LicenseFetcher licenseFetcher, RiskEvaluator? riskE
         {
             Logger.LogInformation("Try loading package cache from {CacheFilePath}", settings.CacheFilePath);
             await packages.TryInitializeFromCache(settings.CacheFilePath);
-            await GitHubApi.LoadResponseCacheAsync(Logger, settings.CacheFilePath);
+            await GitHubApi.LoadCachesAsync(Logger, settings.CacheFilePath, settings);
         }
 
         foreach (IProjectAnalysisStrategy strategy in strategies)
@@ -74,7 +74,7 @@ public class ProjectAnalyzer(LicenseFetcher licenseFetcher, RiskEvaluator? riskE
 
         if (isCachingEnabled)
         {
-            await GitHubApi.SaveResponseCacheAsync(Logger, settings.CacheFilePath);
+            await GitHubApi.SaveCachesAsync(Logger, settings.CacheFilePath);
         }
 
         return new AnalysisResult

--- a/Src/PackageGuard.Core/Risk/Enrichment/GitHubRepositoryRiskEnricher.cs
+++ b/Src/PackageGuard.Core/Risk/Enrichment/GitHubRepositoryRiskEnricher.cs
@@ -12,15 +12,11 @@ namespace PackageGuard.Core.Risk.Enrichment;
 /// <summary>Enriches package risk data using GitHub repository API metadata.</summary>
 internal sealed class GitHubRepositoryRiskEnricher : IEnrichPackageRisk
 {
-    /// <summary>Cache of repository API root URL to risk data. A cached <c>null</c> records a repository whose data
-    /// could not be fetched, so the packages that follow do not repeat the same failing fan-out.</summary>
-    private static readonly Dictionary<string, GitHubRepositoryRiskData?> Cache = new(StringComparer.OrdinalIgnoreCase);
-
     /// <summary>In-flight load tasks per repository API root, preventing duplicate concurrent fetches.</summary>
     private static readonly Dictionary<string, Task<GitHubRepositoryRiskData?>> InFlightLoads =
         new(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>Lock for thread-safe cache and in-flight loads access.</summary>
+    /// <summary>Lock for thread-safe access to the in-flight loads.</summary>
     private static readonly Lock CacheLock = new();
 
     /// <summary>Client for the OpenSSF Scorecard API, which is not subject to the GitHub rate limit.</summary>
@@ -61,30 +57,33 @@ internal sealed class GitHubRepositoryRiskEnricher : IEnrichPackageRisk
 
     private readonly ILogger logger;
     private readonly GitHubApiClient apiClient;
+    private readonly GitHubRepositoryRiskCache repositoryCache;
 
     /// <summary>Creates an enricher that talks to GitHub through the client shared by the whole run.</summary>
     /// <param name="logger">The logger to report fetch problems to.</param>
     /// <param name="gitHubApiKey">The GitHub personal access token to authenticate with, if any.</param>
     public GitHubRepositoryRiskEnricher(ILogger logger, string? gitHubApiKey)
-        : this(logger, GitHubApi.GetOrCreateClient(logger, gitHubApiKey))
+        : this(logger, GitHubApi.GetOrCreateClient(logger, gitHubApiKey), GitHubApi.GetOrCreateRepositoryCache(logger))
     {
     }
 
     /// <summary>Creates an enricher that talks to GitHub through the given client.</summary>
     /// <param name="logger">The logger to report fetch problems to.</param>
     /// <param name="apiClient">The client to send GitHub API requests through.</param>
-    internal GitHubRepositoryRiskEnricher(ILogger logger, GitHubApiClient apiClient)
+    /// <param name="repositoryCache">The cache of repository profiles to read from and add to.</param>
+    internal GitHubRepositoryRiskEnricher(ILogger logger, GitHubApiClient apiClient,
+        GitHubRepositoryRiskCache? repositoryCache = null)
     {
         this.logger = logger;
         this.apiClient = apiClient;
+        this.repositoryCache = repositoryCache ?? new GitHubRepositoryRiskCache(logger);
     }
 
-    /// <summary>Discards the cross-package repository cache. Only used by the tests.</summary>
+    /// <summary>Discards the in-flight repository loads. Only used by the tests.</summary>
     internal static void ClearCache()
     {
         lock (CacheLock)
         {
-            Cache.Clear();
             InFlightLoads.Clear();
         }
     }
@@ -189,13 +188,13 @@ internal sealed class GitHubRepositoryRiskEnricher : IEnrichPackageRisk
     {
         Task<GitHubRepositoryRiskData?> loadTask;
 
+        if (repositoryCache.TryGet(repositoryApiRoot, out GitHubRepositoryRiskData? cached))
+        {
+            return cached;
+        }
+
         lock (CacheLock)
         {
-            if (Cache.TryGetValue(repositoryApiRoot, out GitHubRepositoryRiskData? cached))
-            {
-                return cached;
-            }
-
             if (!InFlightLoads.TryGetValue(repositoryApiRoot, out loadTask!))
             {
                 loadTask = LoadAsync(repositoryApiRoot);
@@ -208,9 +207,9 @@ internal sealed class GitHubRepositoryRiskEnricher : IEnrichPackageRisk
         lock (CacheLock)
         {
             InFlightLoads.Remove(repositoryApiRoot);
-            Cache[repositoryApiRoot] = loaded;
         }
 
+        repositoryCache.Store(repositoryApiRoot, loaded);
         return loaded;
     }
 
@@ -1755,172 +1754,6 @@ internal sealed class GitHubRepositoryRiskEnricher : IEnrichPackageRisk
         return values.Count % 2 == 0
             ? (values[middle - 1] + values[middle]) / 2.0
             : values[middle];
-    }
-
-    /// <summary>Aggregated repository risk metrics for a GitHub repository.</summary>
-    private sealed class GitHubRepositoryRiskData
-    {
-        /// <summary>The canonical HTML URL of the repository as returned by the GitHub API.</summary>
-        public string CanonicalUrl { get; init; } = string.Empty;
-
-        /// <summary>Indicates whether the repository owner is an organization.</summary>
-        public bool OwnerIsOrganization { get; init; }
-
-        /// <summary>The date the repository owner account was created.</summary>
-        public DateTimeOffset? OwnerCreatedAt { get; init; }
-
-        /// <summary>The total number of non-bot contributors.</summary>
-        public int ContributorCount { get; init; }
-
-        /// <summary>The fraction of total contributions made by the top contributor.</summary>
-        public double? TopContributorShare { get; init; }
-
-        /// <summary>The fraction of total contributions made by the top two contributors combined.</summary>
-        public double? TopTwoContributorShare { get; init; }
-
-        /// <summary>The number of maintainers with commit activity in the last six months.</summary>
-        public int? RecentMaintainerCount { get; init; }
-
-        /// <summary>Indicates whether the repository has a README file.</summary>
-        public bool HasReadme { get; init; }
-
-        /// <summary>Indicates whether the README appears to be a boilerplate default.</summary>
-        public bool HasDefaultReadme { get; init; }
-
-        /// <summary>The date of the most recent commit that touched the README file.</summary>
-        public DateTimeOffset? ReadmeUpdatedAt { get; init; }
-
-        /// <summary>Indicates whether the repository has a CONTRIBUTING.md file.</summary>
-        public bool HasContributingGuide { get; init; }
-
-        /// <summary>Indicates whether the repository has a SECURITY.md file.</summary>
-        public bool HasSecurityPolicy { get; init; }
-
-        /// <summary>Indicates whether the security policy contains detailed contact and reporting information.</summary>
-        public bool? HasDetailedSecurityPolicy { get; init; }
-
-        /// <summary>Indicates whether the security policy describes a coordinated disclosure process.</summary>
-        public bool? HasCoordinatedDisclosure { get; init; }
-
-        /// <summary>Indicates whether the repository has a CHANGELOG file.</summary>
-        public bool HasChangelog { get; init; }
-
-        /// <summary>Indicates whether the CHANGELOG appears to be a boilerplate default.</summary>
-        public bool HasDefaultChangelog { get; init; }
-
-        /// <summary>The date of the most recent commit that touched the CHANGELOG file.</summary>
-        public DateTimeOffset? ChangelogUpdatedAt { get; init; }
-
-        /// <summary>The number of currently open bug issues.</summary>
-        public int OpenBugIssueCount { get; init; }
-
-        /// <summary>The number of critical bug issues that have been open for more than six months.</summary>
-        public int StaleCriticalBugIssueCount { get; init; }
-
-        /// <summary>The median number of days until a maintainer first responds to an open bug issue.</summary>
-        public double? MedianIssueResponseDays { get; init; }
-
-        /// <summary>The median number of days until a maintainer first responds to a critical open bug issue.</summary>
-        public double? MedianCriticalIssueResponseDays { get; init; }
-
-        /// <summary>The fraction of open bug issues that have received at least one maintainer response.</summary>
-        public double? IssueResponseCoverage { get; init; }
-
-        /// <summary>The median age in days of currently open bug issues.</summary>
-        public double? MedianOpenBugAgeDays { get; init; }
-
-        /// <summary>The number of bug issues closed in the last 90 days.</summary>
-        public int? ClosedBugIssueCountLast90Days { get; init; }
-
-        /// <summary>The number of bug issues that were reopened after being closed in the last 90 days.</summary>
-        public int? ReopenedBugIssueCountLast90Days { get; init; }
-
-        /// <summary>The fraction of open bug issues that received a maintainer response within seven days.</summary>
-        public double? IssueTriageWithinSevenDaysRate { get; init; }
-
-        /// <summary>The median number of days from pull request creation to merge.</summary>
-        public double? MedianPullRequestMergeDays { get; init; }
-
-        /// <summary>The fraction of recently merged pull requests authored by external contributors.</summary>
-        public double? ExternalContributionRate { get; init; }
-
-        /// <summary>The number of unique reviewers across recently merged pull requests.</summary>
-        public int? UniqueReviewerCount { get; init; }
-
-        /// <summary>The ratio of unique reviewers to total recently merged pull requests.</summary>
-        public double? ReviewerDiversityRatio { get; init; }
-
-        /// <summary>The number of failed workflow runs among the most recent runs on the default branch.</summary>
-        public int? RecentFailedWorkflowCount { get; init; }
-
-        /// <summary>Indicates whether there is at least one recent successful workflow run on the default branch.</summary>
-        public bool? HasRecentSuccessfulWorkflowRun { get; init; }
-
-        /// <summary>The fraction of completed workflow runs that failed.</summary>
-        public double? WorkflowFailureRate { get; init; }
-
-        /// <summary>Indicates whether the workflow runs show a flaky pattern (intermittent failures and successes).</summary>
-        public bool? HasFlakyWorkflowPattern { get; init; }
-
-        /// <summary>The number of required status checks configured on the default branch.</summary>
-        public int? RequiredStatusCheckCount { get; init; }
-
-        /// <summary>The number of distinct operating system platforms targeted by workflow files.</summary>
-        public int? WorkflowPlatformCount { get; init; }
-
-        /// <summary>Indicates whether workflow files contain a coverage reporting signal.</summary>
-        public bool? HasCoverageWorkflowSignal { get; init; }
-
-        /// <summary>Indicates whether workflow files or Scorecard results suggest reproducible builds.</summary>
-        public bool? HasReproducibleBuildSignal { get; init; }
-
-        /// <summary>Indicates whether the repository uses automated dependency update tooling.</summary>
-        public bool? HasDependencyUpdateAutomation { get; init; }
-
-        /// <summary>Indicates whether workflow files contain a test execution signal.</summary>
-        public bool? HasTestSignal { get; init; }
-
-        /// <summary>The OpenSSF Scorecard aggregate score for the repository.</summary>
-        public double? OpenSsfScore { get; init; }
-
-        /// <summary>Indicates whether the default branch has branch protection enabled.</summary>
-        public bool? HasBranchProtection { get; init; }
-
-        /// <summary>Indicates whether workflow files contain a provenance attestation signal.</summary>
-        public bool? HasProvenanceAttestation { get; init; }
-
-        /// <summary>Indicates whether the most recent release has a verified signature.</summary>
-        public bool? HasVerifiedReleaseSignature { get; init; }
-
-        /// <summary>Indicates whether the repository owner is an organization, used as a proxy for a verified publisher.</summary>
-        public bool? HasVerifiedPublisher { get; init; }
-
-        /// <summary>Indicates whether releases include substantive release notes.</summary>
-        public bool? HasReleaseNotes { get; init; }
-
-        /// <summary>Indicates whether all releases use SemVer-compatible tags.</summary>
-        public bool? HasSemVerReleaseTags { get; init; }
-
-        /// <summary>The mean number of days between consecutive releases.</summary>
-        public double? MeanReleaseIntervalDays { get; init; }
-
-        /// <summary>The fraction of consecutive release transitions that were major-version bumps.</summary>
-        public double? MajorReleaseRatio { get; init; }
-
-        /// <summary>The fraction of releases marked as pre-releases.</summary>
-        public double? PrereleaseRatio { get; init; }
-
-        /// <summary>The number of release pairs published within three days of each other, indicating rapid corrections.</summary>
-        public int? RapidReleaseCorrectionCount { get; init; }
-
-        /// <summary>The fraction of sampled commits that have a verified signature.</summary>
-        public double? VerifiedCommitRatio { get; init; }
-
-        /// <summary>The median number of days since the last commit activity for each active maintainer.</summary>
-        public double? MedianMaintainerActivityDays { get; init; }
-
-        /// <summary>The publication date of the most recent release.</summary>
-        public DateTimeOffset? LastReleaseAt { get; init; }
     }
 
     /// <summary>Lightweight snapshot of an open GitHub issue for processing.</summary>

--- a/Src/PackageGuard.Specs/GitHub/GitHubRepositoryRiskCacheSpecs.cs
+++ b/Src/PackageGuard.Specs/GitHub/GitHubRepositoryRiskCacheSpecs.cs
@@ -1,0 +1,160 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PackageGuard.Core.GitHub;
+using PackageGuard.Core.Package;
+using PackageGuard.Core.Risk.Enrichment;
+using PackageGuard.Specs.Common;
+using Pathy;
+
+namespace PackageGuard.Specs.GitHub;
+
+[TestClass]
+[DoNotParallelize]
+public class GitHubRepositoryRiskCacheSpecs
+{
+    [TestInitialize]
+    public void ClearSharedState() => GitHubRepositoryRiskEnricher.ClearCache();
+
+    [TestCleanup]
+    public void ClearSharedStateAfterwards() => GitHubRepositoryRiskEnricher.ClearCache();
+
+    [TestMethod]
+    public async Task Reuses_a_repository_profile_that_a_previous_run_collected()
+    {
+        // Arrange
+        string cachePath = CreateCachePath();
+        var firstRunCache = new GitHubRepositoryRiskCache(NullLogger.Instance);
+        var firstRunHandler = new ScriptedHttpMessageHandler((request, _) => FakeGitHub.Respond(request));
+        await EnrichAsync(firstRunHandler, firstRunCache, CreatePackage("Acme.Widget"));
+        await firstRunCache.SaveAsync(cachePath);
+
+        var laterRunCache = new GitHubRepositoryRiskCache(NullLogger.Instance);
+        await laterRunCache.LoadAsync(cachePath);
+        var laterRunHandler = new ScriptedHttpMessageHandler((request, _) => FakeGitHub.Respond(request));
+        PackageInfo package = CreatePackage("Acme.Widget");
+
+        try
+        {
+            // Act
+            GitHubRepositoryRiskEnricher.ClearCache();
+            await EnrichAsync(laterRunHandler, laterRunCache, package);
+
+            // Assert
+            laterRunHandler.RequestCount.Should().Be(0, "the profile of the repository was already collected");
+            package.HasGitHubRiskData.Should().BeTrue();
+            package.OwnerIsOrganization.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(cachePath)!, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task Collects_a_repository_profile_again_once_it_is_past_its_maximum_age()
+    {
+        // Arrange
+        string cachePath = CreateCachePath();
+        var firstRunCache = new GitHubRepositoryRiskCache(NullLogger.Instance);
+        await EnrichAsync(new ScriptedHttpMessageHandler((request, _) => FakeGitHub.Respond(request)),
+            firstRunCache, CreatePackage("Acme.Widget"));
+
+        await firstRunCache.SaveAsync(cachePath);
+
+        var laterRunCache = new GitHubRepositoryRiskCache(NullLogger.Instance) { MaxAge = TimeSpan.Zero };
+        await laterRunCache.LoadAsync(cachePath);
+        var laterRunHandler = new ScriptedHttpMessageHandler((request, _) => FakeGitHub.Respond(request));
+
+        try
+        {
+            // Act
+            GitHubRepositoryRiskEnricher.ClearCache();
+            await EnrichAsync(laterRunHandler, laterRunCache, CreatePackage("Acme.Widget"));
+
+            // Assert
+            laterRunHandler.RequestCount.Should().BeGreaterThan(0, "the cached profile is too old to reuse");
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(cachePath)!, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task Describes_a_repository_once_however_many_packages_come_out_of_it()
+    {
+        // Arrange
+        var handler = new ScriptedHttpMessageHandler((request, _) => FakeGitHub.Respond(request));
+        var cache = new GitHubRepositoryRiskCache(NullLogger.Instance);
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+        var enricher = new GitHubRepositoryRiskEnricher(NullLogger.Instance, client, cache);
+
+        // Act
+        await enricher.EnrichAsync(CreatePackage("Acme.Widget.Core"));
+        int afterFirstPackage = handler.RequestCount;
+        await enricher.EnrichAsync(CreatePackage("Acme.Widget.Abstractions"));
+        await enricher.EnrichAsync(CreatePackage("Acme.Widget.Extensions"));
+
+        // Assert
+        handler.RequestCount.Should().Be(afterFirstPackage,
+            "the profile is keyed by repository, not by the packages that come out of it");
+    }
+
+    private static async Task EnrichAsync(ScriptedHttpMessageHandler handler, GitHubRepositoryRiskCache cache,
+        PackageInfo package)
+    {
+        using var client = new GitHubApiClient(NullLogger.Instance, apiKey: null, responseCache: null, handler);
+        var enricher = new GitHubRepositoryRiskEnricher(NullLogger.Instance, client, cache);
+        await enricher.EnrichAsync(package);
+    }
+
+    private static string CreateCachePath() =>
+        ChainablePath.Temp / $"packageguard-{Guid.NewGuid():N}" / "cache.bin";
+
+    [TestMethod]
+    public async Task Keeps_a_still_fresh_profile_that_this_run_had_no_use_for()
+    {
+        // Arrange
+        string cachePath = CreateCachePath();
+        var firstRunCache = new GitHubRepositoryRiskCache(NullLogger.Instance);
+        await EnrichAsync(new ScriptedHttpMessageHandler((request, _) => FakeGitHub.Respond(request)),
+            firstRunCache, CreatePackage("Acme.Widget"));
+
+        await firstRunCache.SaveAsync(cachePath);
+
+        var untouchedRunCache = new GitHubRepositoryRiskCache(NullLogger.Instance);
+        await untouchedRunCache.LoadAsync(cachePath);
+
+        try
+        {
+            // Act
+            await untouchedRunCache.SaveAsync(cachePath);
+
+            var laterRunCache = new GitHubRepositoryRiskCache(NullLogger.Instance);
+            await laterRunCache.LoadAsync(cachePath);
+
+            // Assert
+            laterRunCache.TryGet("https://api.github.com/repos/acme/widget", out GitHubRepositoryRiskData data)
+                .Should().BeTrue("a run that needed no profile should not throw the cache away");
+
+            data.Should().NotBeNull();
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(cachePath)!, recursive: true);
+        }
+    }
+
+    private static PackageInfo CreatePackage(string name) =>
+        new()
+        {
+            Name = name,
+            Version = "1.0.0",
+            Source = "NuGet",
+            RepositoryUrl = "https://github.com/acme/widget"
+        };
+}

--- a/Src/PackageGuard.Specs/Package/RiskCacheFreshnessSpecs.cs
+++ b/Src/PackageGuard.Specs/Package/RiskCacheFreshnessSpecs.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using PackageGuard.Core;
+using PackageGuard.Core.Package;
+using Pathy;
+
+namespace PackageGuard.Specs.Package;
+
+[TestClass]
+public class RiskCacheFreshnessSpecs
+{
+    private static readonly SourceRepository Source =
+        new(new PackageSource("https://nuget.org"), Array.Empty<INuGetResourceProvider>());
+
+    [TestMethod]
+    public async Task Reuses_a_cache_entry_that_is_still_within_its_maximum_age()
+    {
+        // Arrange
+        string cachePath = CreateCachePath();
+        await WriteCacheAsync(cachePath, CreateEnrichedPackage(cachedAt: DateTimeOffset.UtcNow.AddHours(-2)));
+
+        var collection = new PackageInfoCollection(NullLogger.Instance, CreateSettings());
+        await collection.TryInitializeFromCache(cachePath);
+
+        // Act
+        PackageInfo package = collection.Find("Bogus", "2.0.0", [Source]);
+
+        // Assert
+        package.Should().NotBeNull();
+        package.HasGitHubRiskData.Should().BeTrue("the entry is fresh, so no signal has to be collected again");
+    }
+
+    [TestMethod]
+    public async Task Drops_the_risk_signals_of_a_cache_entry_that_is_past_its_maximum_age()
+    {
+        // Arrange
+        string cachePath = CreateCachePath();
+        await WriteCacheAsync(cachePath, CreateEnrichedPackage(cachedAt: DateTimeOffset.UtcNow.AddDays(-3)));
+
+        var collection = new PackageInfoCollection(NullLogger.Instance, CreateSettings());
+        await collection.TryInitializeFromCache(cachePath);
+
+        // Act
+        PackageInfo staleLookup = collection.Find("Bogus", "2.0.0", [Source]);
+        PackageInfo refreshed = collection.Add(CreateFreshlyFetchedPackage());
+
+        // Assert
+        staleLookup.Should().BeNull("a stale entry has to be fetched again");
+        refreshed.HasGitHubRiskData.Should().BeFalse("the repository signals have to be collected again");
+        refreshed.HasOsvRiskData.Should().BeFalse("the vulnerability signals have to be collected again");
+        refreshed.HasValidatedLicenseUrl.Should().BeFalse("the license URL has to be validated again");
+    }
+
+    [TestMethod]
+    public async Task Replaces_the_registry_metadata_of_a_stale_entry_with_what_was_just_fetched()
+    {
+        // Arrange
+        string cachePath = CreateCachePath();
+        await WriteCacheAsync(cachePath, CreateEnrichedPackage(cachedAt: DateTimeOffset.UtcNow.AddDays(-3)));
+
+        var collection = new PackageInfoCollection(NullLogger.Instance, CreateSettings());
+        await collection.TryInitializeFromCache(cachePath);
+        collection.Find("Bogus", "2.0.0", [Source]);
+
+        // Act
+        PackageInfo refreshed = collection.Add(CreateFreshlyFetchedPackage());
+
+        // Assert
+        refreshed.LatestStableVersion.Should().Be("3.0.0", "a newer version was released since the entry was written");
+        refreshed.DownloadCount.Should().Be(9999);
+        refreshed.IsMajorVersionBehindLatest.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Stamps_a_refreshed_entry_so_that_it_does_not_stay_stale_for_good()
+    {
+        // Arrange
+        string cachePath = CreateCachePath();
+        await WriteCacheAsync(cachePath, CreateEnrichedPackage(cachedAt: DateTimeOffset.UtcNow.AddDays(-3)));
+
+        var firstRun = new PackageInfoCollection(NullLogger.Instance, CreateSettings());
+        await firstRun.TryInitializeFromCache(cachePath);
+        firstRun.Find("Bogus", "2.0.0", [Source]);
+        firstRun.Add(CreateFreshlyFetchedPackage());
+        await firstRun.WriteToCache(cachePath);
+
+        var secondRun = new PackageInfoCollection(NullLogger.Instance, CreateSettings());
+        await secondRun.TryInitializeFromCache(cachePath);
+
+        // Act
+        PackageInfo package = secondRun.Find("Bogus", "2.0.0", [Source]);
+
+        // Assert
+        package.Should().NotBeNull("the entry was refreshed during the previous run, so it is fresh again");
+    }
+
+    [TestMethod]
+    public async Task Keeps_reusing_the_cache_when_risk_reporting_is_off()
+    {
+        // Arrange
+        string cachePath = CreateCachePath();
+        await WriteCacheAsync(cachePath, CreateEnrichedPackage(cachedAt: DateTimeOffset.UtcNow.AddYears(-1)));
+
+        var collection = new PackageInfoCollection(NullLogger.Instance, new AnalyzerSettings { ReportRisk = false });
+        await collection.TryInitializeFromCache(cachePath);
+
+        // Act
+        PackageInfo package = collection.Find("Bogus", "2.0.0", [Source]);
+
+        // Assert
+        package.Should().NotBeNull("without risk reporting the age of an entry does not matter");
+    }
+
+    private static AnalyzerSettings CreateSettings() => new()
+    {
+        ReportRisk = true,
+        RiskCacheMaxAge = TimeSpan.FromHours(24)
+    };
+
+    private static string CreateCachePath() =>
+        ChainablePath.Temp / $"packageguard-{Guid.NewGuid():N}" / "cache.bin";
+
+    private static async Task WriteCacheAsync(string cachePath, PackageInfo package)
+    {
+        var collection = new PackageInfoCollection(NullLogger.Instance) { package };
+        await collection.WriteToCache(cachePath);
+    }
+
+    private static PackageInfo CreateEnrichedPackage(DateTimeOffset cachedAt) => new()
+    {
+        Name = "Bogus",
+        Version = "2.0.0",
+        Source = "nuget.org",
+        SourceUrl = Source.PackageSource.Source,
+        License = "MIT",
+        CacheUpdatedAt = cachedAt,
+        HasGitHubRiskData = true,
+        HasOsvRiskData = true,
+        HasValidatedLicenseUrl = true,
+        ContributorCount = 5,
+        DownloadCount = 1234,
+        LatestStableVersion = "2.0.1"
+    };
+
+    private static PackageInfo CreateFreshlyFetchedPackage() => new()
+    {
+        Name = "Bogus",
+        Version = "2.0.0",
+        Source = "nuget.org",
+        SourceUrl = Source.PackageSource.Source,
+        License = "MIT",
+        DownloadCount = 9999,
+        LatestStableVersion = "3.0.0",
+        IsMajorVersionBehindLatest = true
+    };
+}


### PR DESCRIPTION
Last of four. Stacked on #241.

## What was wrong

`--risk-cache-max-age` did not do what it says, in both directions at once.

`CacheUpdatedAt` was only stamped on entries that had none (`if (package.CacheUpdatedAt == default)`, and the field is nullable), so an entry kept the moment it was first written for good. Once past the maximum age it stayed past it — **every later run refetched the metadata of every package, forever.**

Meanwhile the risk signals never refreshed at all. `HasGitHubRiskData` and `HasOsvRiskData` are persisted, and the enrichers skip a package that carries them, so an expired entry kept the signals it was written with. **The two bugs masked each other:** constant refetching of package metadata, and risk data frozen after the first run.

The refetch was also thrown away. Merging a freshly fetched package into a cached entry only carried the source, repository URL, and license across, so the values that actually go out of date for a fixed package version — the latest version it lags behind, its download count, its deprecation status — stayed at what they were when the entry was first written.

Separately, a repository's risk profile was stored on every package that came out of it. Dozens of packages can share one repository, so the same fifty fields were written to `cache.bin` dozens of times, and whether the profile was collected again depended on the freshness of individual packages rather than of the repository.

## What changed

Entries are stamped when written or refreshed and keep their timestamp when reused, so they expire on schedule and go fresh again afterwards. Expiring an entry clears its risk signals, which is what makes the enrichers collect them again, and drops the registry values that go out of date so the merge refills them.

The repository profile is now keyed by the repository's API root and persisted next to the package cache with its own maximum age. One package going stale no longer forces a repository to be described again, one repository is described once however many packages reference it, and the profile survives to the next run. A run that needed no profile keeps what is on disk rather than writing an empty cache, so a quiet run does not undo the caching for the run after it.

`GitHubRepositoryRiskData` moves out of the enricher into the `GitHub` namespace, since it is now a persisted type rather than an implementation detail.

## Testing

Nine new unit tests covering reuse within the maximum age, signal invalidation past it, the refreshed registry values landing, re-stamping across two runs, caching staying unconditional when risk reporting is off, cross-run profile reuse, profile expiry, one-profile-per-repository, and the empty-cache guard. Full suite green (231 tests), public API surface unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)