### PR TITLE
Resolve the nuspec repository URL before falling back to GitHub for a license

### DIFF
--- a/Src/PackageGuard.Core/CSharp/NuGetPackageAnalyzer.cs
+++ b/Src/PackageGuard.Core/CSharp/NuGetPackageAnalyzer.cs
@@ -76,6 +76,14 @@ public class NuGetPackageAnalyzer(ILogger logger, LicenseFetcher licenseFetcher)
                 package = packages.Add(package);
                 NuspecMetadata? nuspecMetadata = TryReadNuspecMetadata(projectPath, packageName, packageVersion);
 
+                // Prefer the nuspec's <repository> URL over the catalog's projectUrl (e.g. a blog post) *before*
+                // fetching a missing license, since the GitHub fallback below depends on RepositoryUrl actually
+                // pointing at the source repository.
+                if (nuspecMetadata?.RepositoryUrl.IsNotNullOrWhiteSpace() == true)
+                {
+                    package.RepositoryUrl = nuspecMetadata.RepositoryUrl;
+                }
+
                 // If the license information is not explicitly specified in the package, but the metadata does contain it,
                 // assume that the license is declared.
                 if (package.License is null && nuspecMetadata?.License is not null)
@@ -89,11 +97,6 @@ public class NuGetPackageAnalyzer(ILogger logger, LicenseFetcher licenseFetcher)
                 if (package.License is null)
                 {
                     await licenseFetcher.AmendWithMissingLicenseInformation(package);
-                }
-
-                if (nuspecMetadata?.RepositoryUrl.IsNotNullOrWhiteSpace() == true)
-                {
-                    package.RepositoryUrl = nuspecMetadata.RepositoryUrl;
                 }
             }
         }

--- a/Src/PackageGuard.Specs/CSharp/ProjectAnalyzerSpecs.cs
+++ b/Src/PackageGuard.Specs/CSharp/ProjectAnalyzerSpecs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using CliWrap;
 using FluentAssertions;
@@ -143,6 +144,38 @@ public class ProjectAnalyzerSpecs
             Version = "8.3.0",
             License = "Unknown"
         });
+    }
+
+    [TestMethod]
+    public async Task Resolves_the_license_via_the_nuspec_repository_url_when_the_project_url_is_not_a_repository()
+    {
+        // Arrange
+
+        // NetArchTest.Rules 1.3.2 declares neither a <license> nor a licenseUrl, and its projectUrl points to a
+        // blog post rather than its GitHub repository. Its nuspec does declare a <repository> element pointing at
+        // https://github.com/BenMorris/NetArchTest, which the GitHub license fallback should use instead. See
+        // https://github.com/dennisdoomen/packageguard/issues/246.
+        var analyzer = new ProjectAnalyzer(licenseFetcher);
+        var projectPath = ChainablePath.Current / "TestCases" / "NetArchTestApp" / "ConsoleApp.csproj";
+
+        // Act
+        AnalysisResult result = await analyzer.ExecuteAnalysisWithRisk(projectPath, new AnalyzerSettings
+        {
+            ForceRestore = true
+        }, _ => new ProjectPolicy
+        {
+            AllowList = new AllowList
+            {
+                Licenses = ["mit"]
+            }
+        });
+
+        // Assert
+        result.Violations.Should().BeEmpty();
+        result.Packages.Should().ContainSingle(p => p.Name == "NetArchTest.Rules");
+        var package = result.Packages.Single(p => p.Name == "NetArchTest.Rules");
+        package.License.Should().Be("MIT");
+        package.RepositoryUrl.Should().Be("https://github.com/BenMorris/NetArchTest");
     }
 
     [TestMethod]

--- a/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
+++ b/Src/PackageGuard.Specs/PackageGuard.Specs.csproj
@@ -56,6 +56,10 @@
       <None Include="TestCases\UnreachableFeed\Program.cs">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <Compile Remove="TestCases\NetArchTestApp\Program.cs" />
+      <None Include="TestCases\NetArchTestApp\Program.cs">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
       <Compile Remove="TestCases\Prerelease\UnitTest1.cs" />
       <None Include="TestCases\Prerelease\UnitTest1.cs">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -139,6 +143,12 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Include="TestCases\UnreachableFeed\ConsoleApp.csproj">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Include="TestCases\NetArchTestApp\ConsoleApp.sln">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Include="TestCases\NetArchTestApp\ConsoleApp.csproj">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Include="TestCases\UnknownLicense\ConsoleApp.csproj">

--- a/Src/PackageGuard.Specs/TestCases/NetArchTestApp/ConsoleApp.csproj
+++ b/Src/PackageGuard.Specs/TestCases/NetArchTestApp/ConsoleApp.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
+  </ItemGroup>
+
+</Project>

--- a/Src/PackageGuard.Specs/TestCases/NetArchTestApp/ConsoleApp.sln
+++ b/Src/PackageGuard.Specs/TestCases/NetArchTestApp/ConsoleApp.sln
@@ -1,0 +1,16 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp", "ConsoleApp.csproj", "{2A6A6C6E-9E3A-4C2E-9F5E-2B7C0B6B4E31}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2A6A6C6E-9E3A-4C2E-9F5E-2B7C0B6B4E31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A6A6C6E-9E3A-4C2E-9F5E-2B7C0B6B4E31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A6A6C6E-9E3A-4C2E-9F5E-2B7C0B6B4E31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A6A6C6E-9E3A-4C2E-9F5E-2B7C0B6B4E31}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Src/PackageGuard.Specs/TestCases/NetArchTestApp/Program.cs
+++ b/Src/PackageGuard.Specs/TestCases/NetArchTestApp/Program.cs
@@ -1,0 +1,2 @@
+// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");


### PR DESCRIPTION
## Summary

PackageGuard reported "Unable to determine license" for `NetArchTest.Rules` 1.3.2, an MIT-licensed package, even though the GitHub fallback lookup needed to resolve it was already implemented. This fixes the ordering bug that prevented it from being used.

## Changes

### Resolve the nuspec repository URL before falling back to GitHub for a license

`NetArchTest.Rules` 1.3.2 declares no `license` expression or `licenseUrl`, and its `projectUrl` points to a blog post rather than its source repository. Its nuspec does declare a `<repository>` element pointing at its real, MIT-licensed GitHub repository — but that URL was only applied to the package *after* the GitHub license fallback had already run against the (unusable) `projectUrl` and given up.

The fix reorders the two steps: the nuspec's repository URL is now applied before the license fallback runs, so the GitHub lookup gets the real repository and can resolve the license correctly.

A regression test reproduces the exact `NetArchTest.Rules` 1.3.2 scenario from the issue.

Fixes https://github.com/dennisdoomen/packageguard/issues/246
