### PR TITLE
Fix crash on null GitHub license and always log full exception details

### DIFF
--- a/Src/PackageGuard.Core/CSharp/FetchingStrategies/GitHubLicenseFetcher.cs
+++ b/Src/PackageGuard.Core/CSharp/FetchingStrategies/GitHubLicenseFetcher.cs
@@ -67,6 +67,7 @@ public class GitHubLicenseFetcher : IFetchLicense
     private static string? ReadSpdxIdentifier(JsonDocument document)
     {
         if (!document.RootElement.TryGetProperty("license", out JsonElement license) ||
+            license.ValueKind != JsonValueKind.Object ||
             !license.TryGetProperty("spdx_id", out JsonElement spdxId))
         {
             return null;

--- a/Src/PackageGuard/Program.cs
+++ b/Src/PackageGuard/Program.cs
@@ -38,6 +38,14 @@ var app = new CommandApp<AnalyzeCommand>(registrar).WithData(logger);
 app.Configure(c =>
 {
     c.CaseSensitivity(CaseSensitivity.None);
+
+    // Spectre.Console.Cli only prints the exception's message by default, discarding the stack trace.
+    // Always log the full exception so unexpected failures can be diagnosed from the console output.
+    c.SetExceptionHandler((ex, _) =>
+    {
+        logger.LogError(ex, "Unhandled exception: {Message}", ex.Message);
+        return -1;
+    });
 });
 
 return app.Run(args);


### PR DESCRIPTION
## Problem

Running `packageguard --report-risk ... --sbom=spdx ...` against a solution crashed with:

```
Error: The requested operation requires an element of type 'Object', but the target element has type 'Null'.
```

## Root cause

`GitHubLicenseFetcher.ReadSpdxIdentifier` called `license.TryGetProperty("spdx_id", ...)` without checking whether the `"license"` property was JSON `null`. GitHub's repository API returns `"license": null` when it can't detect a license (e.g. for `Microsoft.DotNet.PlatformAbstractions`), and calling `TryGetProperty` on a JSON `null` element throws.

Because the exception handler for Spectre.Console.Cli only prints `ex.Message`, this crashed the whole scan with no stack trace to diagnose it.

## Fixes

1. **`GitHubLicenseFetcher.cs`** — guard against a non-object `license` element before reading `spdx_id`.
2. **`Program.cs`** — configure Spectre.Console.Cli's `SetExceptionHandler` to log the full exception (including stack trace and inner exceptions) via the logger, instead of relying on Spectre's default of only printing the message.

## Verification

- Rebuilt and re-ran the full failing command against a real solution; it now completes successfully, producing the risk report and SBOM.
- Simulated an unhandled exception (malformed config file) and confirmed the console now logs the complete exception chain and stack trace.