### PR TITLE
Read top-level OSV severity metadata

### DIFF
--- a/Src/PackageGuard.Core/Risk/Enrichment/OsvRiskEnricher.cs
+++ b/Src/PackageGuard.Core/Risk/Enrichment/OsvRiskEnricher.cs
@@ -611,12 +611,12 @@ internal sealed class OsvRiskEnricher(ILogger logger, HttpClient? httpClient = n
     /// </summary>
     private static IEnumerable<string> EnumerateTextSeverities(JsonElement vulnerability)
     {
-        if (TryReadTextSeverity(vulnerability, "ecosystem_specific", out string? ecosystemSeverity))
+        if (TryReadTextSeverity(vulnerability, "ecosystem_specific", out string ecosystemSeverity))
         {
             yield return ecosystemSeverity;
         }
 
-        if (TryReadTextSeverity(vulnerability, "database_specific", out string? databaseSeverity))
+        if (TryReadTextSeverity(vulnerability, "database_specific", out string databaseSeverity))
         {
             yield return databaseSeverity;
         }
@@ -628,12 +628,12 @@ internal sealed class OsvRiskEnricher(ILogger logger, HttpClient? httpClient = n
 
         foreach (JsonElement affectedPackage in affected.EnumerateArray())
         {
-            if (TryReadTextSeverity(affectedPackage, "ecosystem_specific", out string? affectedEcosystemSeverity))
+            if (TryReadTextSeverity(affectedPackage, "ecosystem_specific", out string affectedEcosystemSeverity))
             {
                 yield return affectedEcosystemSeverity;
             }
 
-            if (TryReadTextSeverity(affectedPackage, "database_specific", out string? affectedDatabaseSeverity))
+            if (TryReadTextSeverity(affectedPackage, "database_specific", out string affectedDatabaseSeverity))
             {
                 yield return affectedDatabaseSeverity;
             }

--- a/Src/PackageGuard.Core/Risk/Enrichment/OsvRiskEnricher.cs
+++ b/Src/PackageGuard.Core/Risk/Enrichment/OsvRiskEnricher.cs
@@ -547,7 +547,7 @@ internal sealed class OsvRiskEnricher(ILogger logger, HttpClient? httpClient = n
         {
             if (severity.TryGetProperty("score", out JsonElement scoreElement))
             {
-                double score = ParseScore(scoreElement.GetString());
+                double score = ParseScore(scoreElement);
                 if (score > 0)
                 {
                     return score;
@@ -606,10 +606,21 @@ internal sealed class OsvRiskEnricher(ILogger logger, HttpClient? httpClient = n
     }
 
     /// <summary>
-    /// Yields text severity strings sourced from <c>ecosystem_specific</c> and <c>database_specific</c> objects within the affected entries.
+    /// Yields text severity strings sourced from top-level and affected-entry <c>ecosystem_specific</c> /
+    /// <c>database_specific</c> metadata.
     /// </summary>
     private static IEnumerable<string> EnumerateTextSeverities(JsonElement vulnerability)
     {
+        if (TryReadTextSeverity(vulnerability, "ecosystem_specific", out string? ecosystemSeverity))
+        {
+            yield return ecosystemSeverity;
+        }
+
+        if (TryReadTextSeverity(vulnerability, "database_specific", out string? databaseSeverity))
+        {
+            yield return databaseSeverity;
+        }
+
         if (!vulnerability.TryGetProperty("affected", out JsonElement affected) || affected.ValueKind != JsonValueKind.Array)
         {
             yield break;
@@ -617,28 +628,57 @@ internal sealed class OsvRiskEnricher(ILogger logger, HttpClient? httpClient = n
 
         foreach (JsonElement affectedPackage in affected.EnumerateArray())
         {
-            if (affectedPackage.TryGetProperty("ecosystem_specific", out JsonElement ecosystemSpecific) &&
-                ecosystemSpecific.ValueKind == JsonValueKind.Object &&
-                ecosystemSpecific.TryGetProperty("severity", out JsonElement severity))
+            if (TryReadTextSeverity(affectedPackage, "ecosystem_specific", out string? affectedEcosystemSeverity))
             {
-                string? value = severity.GetString();
-                if (!string.IsNullOrWhiteSpace(value))
-                {
-                    yield return value;
-                }
+                yield return affectedEcosystemSeverity;
             }
 
-            if (affectedPackage.TryGetProperty("database_specific", out JsonElement databaseSpecific) &&
-                databaseSpecific.ValueKind == JsonValueKind.Object &&
-                databaseSpecific.TryGetProperty("severity", out JsonElement databaseSeverity))
+            if (TryReadTextSeverity(affectedPackage, "database_specific", out string? affectedDatabaseSeverity))
             {
-                string? value = databaseSeverity.GetString();
-                if (!string.IsNullOrWhiteSpace(value))
-                {
-                    yield return value;
-                }
+                yield return affectedDatabaseSeverity;
             }
         }
+    }
+
+    /// <summary>
+    /// Reads a text severity value from an <c>ecosystem_specific</c> or <c>database_specific</c> object, when present.
+    /// </summary>
+    private static bool TryReadTextSeverity(JsonElement element, string propertyName, out string severity)
+    {
+        severity = string.Empty;
+
+        if (!element.TryGetProperty(propertyName, out JsonElement nestedObject) || nestedObject.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!nestedObject.TryGetProperty("severity", out JsonElement severityValue))
+        {
+            return false;
+        }
+
+        string? value = severityValue.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        severity = value;
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a CVSS vector string or plain numeric score into a <see cref="double"/>; returns <c>0</c> when parsing fails.
+    /// </summary>
+    private static double ParseScore(JsonElement scoreElement)
+    {
+        if (scoreElement.ValueKind == JsonValueKind.Number && scoreElement.TryGetDouble(out double numericScore))
+        {
+            return numericScore;
+        }
+
+        string? score = scoreElement.ValueKind == JsonValueKind.String ? scoreElement.GetString() : null;
+        return ParseScore(score);
     }
 
     /// <summary>

--- a/Src/PackageGuard.Specs/Risk/Enrichment/OsvRiskEnricherBatchSpecs.cs
+++ b/Src/PackageGuard.Specs/Risk/Enrichment/OsvRiskEnricherBatchSpecs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -68,6 +69,48 @@ public class OsvRiskEnricherBatchSpecs
     }
 
     [TestMethod]
+    public async Task Reads_numeric_severity_scores_from_OSV_payloads()
+    {
+        // Arrange
+        var handler = new ScriptedHttpMessageHandler((request, _) =>
+            request.RequestUri!.AbsolutePath.EndsWith("/query") || request.RequestUri.AbsolutePath.EndsWith("/querybatch")
+                ? ScriptedResponse.Json(QueryWithNumericSeverity)
+                : throw new InvalidOperationException($"Unexpected OSV URL: {request.RequestUri}"));
+
+        var enricher = new OsvRiskEnricher(NullLogger.Instance, new HttpClient(handler));
+        PackageInfo package = CreatePackages(1).Single();
+
+        // Act
+        await enricher.EnrichAsync(package);
+
+        // Assert
+        package.VulnerabilityCount.Should().Be(1);
+        package.MaxVulnerabilitySeverity.Should().BeApproximately(9.8, 0.01);
+        package.Vulnerabilities.Should().ContainSingle().Which.Severity.Should().BeApproximately(9.8, 0.01);
+    }
+
+    [TestMethod]
+    public async Task Reads_text_severity_scores_from_top_level_OSV_metadata()
+    {
+        // Arrange
+        var handler = new ScriptedHttpMessageHandler((request, _) =>
+            request.RequestUri!.AbsolutePath.EndsWith("/query") || request.RequestUri.AbsolutePath.EndsWith("/querybatch")
+                ? ScriptedResponse.Json(QueryWithTopLevelDatabaseSeverity)
+                : throw new InvalidOperationException($"Unexpected OSV URL: {request.RequestUri}"));
+
+        var enricher = new OsvRiskEnricher(NullLogger.Instance, new HttpClient(handler));
+        PackageInfo package = CreatePackages(1).Single();
+
+        // Act
+        await enricher.EnrichAsync(package);
+
+        // Assert
+        package.VulnerabilityCount.Should().Be(1);
+        package.MaxVulnerabilitySeverity.Should().BeApproximately(8.0, 0.01);
+        package.Vulnerabilities.Should().ContainSingle().Which.Severity.Should().BeApproximately(8.0, 0.01);
+    }
+
+    [TestMethod]
     public async Task Falls_back_to_a_single_query_when_the_batch_result_is_truncated()
     {
         // Arrange
@@ -121,4 +164,35 @@ public class OsvRiskEnricherBatchSpecs
           "references": [{"url": "https://example.com/advisory"}]
         }
         """;
+
+    private const string QueryWithNumericSeverity =
+        """
+        {
+          "vulns": [
+            {
+              "id": "GHSA-1111-2222-3333",
+              "modified": "2026-01-01T00:00:00Z",
+              "aliases": ["CVE-2026-0002"],
+              "severity": [{"type": "CVSS_V3", "score": 9.8}],
+              "references": [{"url": "https://example.com/advisory-2"}]
+            }
+          ]
+        }
+        """;
+
+    private const string QueryWithTopLevelDatabaseSeverity =
+        """
+        {
+          "vulns": [
+            {
+              "id": "GHSA-1111-2222-3333",
+              "modified": "2026-01-01T00:00:00Z",
+              "database_specific": { "severity": "HIGH" },
+              "severity": [{"type": "CVSS_V3", "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"}],
+              "references": [{"url": "https://example.com/advisory-3"}]
+            }
+          ]
+        }
+        """;
+
 }


### PR DESCRIPTION
## Summary

PackageGuard was reporting zero severity for some OSV advisories when the advisory exposed its severity in top-level metadata or as a CVSS vector string instead of only inside affected entries. This change reads those values before falling back to zero and covers both shapes with regression tests.

## Changes

- Read severity values from top-level `ecosystem_specific` and `database_specific` objects as well as nested affected entries.
- Parse numeric and string CVSS scores consistently before mapping them to a numeric severity.
- Add regression tests for numeric severity payloads and the top-level text-severity metadata returned by real OSV advisories.

## Combined effect

The SBOM and risk reports now show the real severity for advisories like GHSA-7jgj-8wvc-jh57 and GHSA-7mfr-774f-w5r9 instead of `0.0` when the API includes severity metadata in those alternate formats.